### PR TITLE
Hotfix for assemblyId

### DIFF
--- a/beacon_api/api/query.py
+++ b/beacon_api/api/query.py
@@ -52,7 +52,7 @@ async def query_request_handler(params):
                      'endMin': position[4],
                      'endMax': position[5],
                      'referenceBases': request.get("referenceBases"),
-                     'assemblyId': request.get("assemblyId", "GRCh38"),
+                     'assemblyId': request.get("assemblyId"),
                      'datasetIds': request.get("datasetIds", []),
                      'includeDatasetResponses': request.get("includeDatasetResponses", "NONE")}
     required_alternative = ["alternateBases", "variantType"]
@@ -62,8 +62,9 @@ async def query_request_handler(params):
     controlled_datasets = await fetch_controlled_datasets(params[0], request.get("datasetIds"))
     access_type, accessible_datasets = access_resolution(request, params[3], controlled_datasets, request.get("datasetIds"))
 
-    datasets = await find_datasets(params[0], position, request.get("referenceName"), request.get("referenceBases"),
-                                   alternate, accessible_datasets, access_type, request.get("includeDatasetResponses", "NONE"))
+    datasets = await find_datasets(params[0], request.get("assemblyId"), position, request.get("referenceName"),
+                                   request.get("referenceBases"), alternate,
+                                   accessible_datasets, access_type, request.get("includeDatasetResponses", "NONE"))
 
     beacon_response = {"beaconId": '.'.join(reversed(params[4].split('.'))),
                        "apiVersion": __apiVersion__,

--- a/beacon_api/schemas/info.json
+++ b/beacon_api/schemas/info.json
@@ -112,7 +112,7 @@
           },
           "assemblyId": {
             "type": "string",
-            "pattern": "^(GRCh[0-9]+([.]p[0-9]+)?)$"
+            "pattern": "^((GRCh|hg)[0-9]+([.]p[0-9]+)?)$"
           },
           "createDateTime": {
             "type": "string",

--- a/beacon_api/schemas/query.json
+++ b/beacon_api/schemas/query.json
@@ -53,7 +53,7 @@
     },
     "assemblyId": {
       "type": "string",
-      "pattern": "^(GRCh[0-9]+([.]p[0-9]+)?)$"
+      "pattern": "^((GRCh|hg)[0-9]+([.]p[0-9]+)?)$"
     },
     "datasetIds": {
       "type": "array",

--- a/beacon_api/schemas/response.json
+++ b/beacon_api/schemas/response.json
@@ -69,7 +69,7 @@
         },
         "assemblyId": {
           "type": "string",
-          "pattern": "^(GRCh[0-9]+([.]p[0-9]+)?)$"
+          "pattern": "^((GRCh|hg)[0-9]+([.]p[0-9]+)?)$"
         },
         "datasetIds": {
           "type": "array",

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -123,7 +123,8 @@ def handle_wildcard(sequence):
         return f"='{sequence}'"
 
 
-async def fetch_filtered_dataset(db_pool, position, chromosome, reference, alternate, datasets=None, access_type=None, misses=False):
+async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, reference, alternate,
+                                 datasets=None, access_type=None, misses=False):
     """Execute filter datasets.
 
     There is an Uber query that aims to be all inclusive.
@@ -159,6 +160,7 @@ async def fetch_filtered_dataset(db_pool, position, chromosome, reference, alter
                             a.frequency, {"FALSE" if misses else "TRUE"} as "exists"
                             FROM {DB_SCHEMA}beacon_data_table a, {DB_SCHEMA}beacon_dataset_table b
                             WHERE a.datasetId=b.datasetId
+                            AND b.assemblyId='{assembly_id}'
                             AND {"NOT" if misses else ''} ({start_pos} AND {end_pos}
                             AND {startMax_pos} AND {startMin_pos}
                             AND {endMin_pos} AND {endMax_pos}
@@ -192,7 +194,7 @@ def filter_exists(include_dataset, datasets):
         return [d for d in datasets if d['exists'] is False]
 
 
-async def find_datasets(db_pool, position, chromosome, reference, alternate, dataset_ids, access_type, include_dataset):
+async def find_datasets(db_pool, assembly_id, position, chromosome, reference, alternate, dataset_ids, access_type, include_dataset):
     """Find datasets based on filter parameters.
 
     This also takes into consideration the token value as to establish permissions.
@@ -203,10 +205,10 @@ async def find_datasets(db_pool, position, chromosome, reference, alternate, dat
     miss_datasets = []
     response = []
     # if include_dataset != 'NONE':
-    hit_datasets = await fetch_filtered_dataset(db_pool, position, chromosome, reference, alternate,
+    hit_datasets = await fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, reference, alternate,
                                                 dataset_ids, access_type)
     if include_dataset in ['ALL', 'MISS']:
-        miss_datasets = await fetch_filtered_dataset(db_pool, position, chromosome, reference, alternate,
+        miss_datasets = await fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, reference, alternate,
                                                      [item["datasetId"] for item in hit_datasets],
                                                      access_type, misses=True)
     # if include_dataset == 'MISS':

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -16,9 +16,12 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
 
 
+TESTS_NUMBER = 9
+
+
 async def test_info():
     """Test the info endpoint."""
-    LOG.debug('[1/8] Test info endpoint')
+    LOG.debug(f'[1/{TESTS_NUMBER}] Test info endpoint')
     async with aiohttp.ClientSession() as session:
         async with session.get('http://localhost:5050/') as resp:
             data = await resp.json()
@@ -30,7 +33,7 @@ async def test_info():
 
 async def test_get_query_1():
     """Test query GET endpoint."""
-    LOG.debug('[2/8] Test get query')
+    LOG.debug(f'[2/{TESTS_NUMBER}] Test get query')
     params = {'assemblyId': 'GRCh38', 'referenceName': 'MT',
               'start': 9, 'referenceBases': 'T', 'alternateBases': 'C',
               'includeDatasetResponses': 'HIT'}
@@ -48,7 +51,7 @@ async def test_get_query_1():
 
 async def test_get_query_2():
     """Test query GET endpoint."""
-    LOG.debug('[3/8] Test get query')
+    LOG.debug(f'[3/{TESTS_NUMBER}] Test get query')
     params = {'assemblyId': 'GRCh38', 'referenceName': 'MT',
               'start': 9, 'referenceBases': 'T', 'variantType': 'SNP',
               'includeDatasetResponses': 'HIT'}
@@ -66,7 +69,7 @@ async def test_get_query_2():
 
 async def test_get_query_3():
     """Test query GET endpoint."""
-    LOG.debug('[4/8] Test get query')
+    LOG.debug(f'[4/{TESTS_NUMBER}] Test get query')
     params = {'assemblyId': 'GRCh38',
               'start': 9, 'referenceBases': 'T', 'alternateBases': 'C',
               'includeDatasetResponses': 'HIT'}
@@ -83,7 +86,7 @@ async def test_get_query_3():
 
 async def test_get_query_4():
     """Test query GET endpoint."""
-    LOG.debug('[5/8] Test get query')
+    LOG.debug(f'[5/{TESTS_NUMBER}] Test get query')
     params = {'assemblyId': 'GRCh38', 'referenceName': 'MT',
               'start': 63, 'referenceBases': 'CT', 'alternateBases': 'NN',
               'includeDatasetResponses': 'HIT'}
@@ -101,7 +104,7 @@ async def test_get_query_4():
 
 async def test_post_query_1():
     """Test query POST endpoint."""
-    LOG.debug('[6/8] Test post query')
+    LOG.debug(f'[6/{TESTS_NUMBER}] Test post query')
     payload = {"referenceName": "MT",
                "start": 9,
                "startMax": 0,
@@ -126,7 +129,7 @@ async def test_post_query_1():
 
 async def test_post_query_2():
     """Test query POST endpoint."""
-    LOG.debug('[7/8] Test post query')
+    LOG.debug(f'[7/{TESTS_NUMBER}] Test post query')
     payload = {"referenceName": "MT",
                "start": 9,
                "startMax": 0,
@@ -151,7 +154,7 @@ async def test_post_query_2():
 
 async def test_post_query_3():
     """Test query POST endpoint."""
-    LOG.debug('[8/8] Test post query')
+    LOG.debug(f'[8/{TESTS_NUMBER}] Test post query')
     payload = {"start": 9,
                "startMax": 0,
                "end": 0,
@@ -172,6 +175,19 @@ async def test_post_query_3():
                 sys.exit('Query POST Endpoint Error!')
 
 
+async def test_get_query_bad_1():
+    """Test query GET endpoint."""
+    LOG.debug(f'[9/{TESTS_NUMBER}] Test get query')
+    params = {'assemblyId': 'GRCh99', 'referenceName': 'MT',
+              'start': 63, 'referenceBases': 'CT', 'alternateBases': 'NN',
+              'includeDatasetResponses': 'HIT'}
+    async with aiohttp.ClientSession() as session:
+        async with session.get('http://localhost:5050/query', params=params) as resp:
+            data = await resp.json()
+            print(data)
+            assert data['exists'] is False, sys.exit('Query GET Endpoint Error!')
+
+
 async def main():
     """Run the tests."""
     LOG.debug('Start integration tests')
@@ -183,6 +199,7 @@ async def main():
     await test_post_query_1()
     await test_post_query_2()
     await test_post_query_3()
+    await test_get_query_bad_1()
     LOG.debug('All integration tests have passed')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp_cors
 asyncpg
 jsonschema==3.0.0a3
 Cython
-cyvcf2
+cyvcf2==0.10.1
 tox
 uvloop
 aiocache

--- a/tests/test_data_query.py
+++ b/tests/test_data_query.py
@@ -116,7 +116,7 @@ class TestDataQueryFunctions(asynctest.TestCase):
         mock_filtered.return_value = []
         token = dict()
         token["bona_fide_status"] = False
-        result = await find_datasets(None, None, 'Y', 'T', 'C', [], token, "NONE")
+        result = await find_datasets(None, 'GRCh38', None, 'Y', 'T', 'C', [], token, "NONE")
         self.assertEqual(result, [])
 
     # async def test_fetch_metadata(self):


### PR DESCRIPTION
This PR addresses the issue #57, adds a new regex to `assemblyId`: `^((GRCh|hg)[0-9]+([.]p[0-9]+)?)$` and also adds an integration test to verify for issue #57.