### PR TITLE
beacon_init optimisation

### DIFF
--- a/beacon_api/utils/db_load.py
+++ b/beacon_api/utils/db_load.py
@@ -98,20 +98,19 @@ class BeaconDB:
         ac = []
         vt = []
         alt = variant.ALT
-        an = variant.num_called*2
         me_type = ['dup:tandem', 'del:me', 'ins:me']
         # sv_type = ['dup', 'inv', 'ins', 'del', 'cnv']
         # supported_vt = ['snp', 'indel', 'mnp', 'dup', 'inv', 'ins', 'del']
         for k, v in variant.INFO:
             if k == 'AC':
                 ac = self._handle_type(v, int)
-            if k == 'AF':
-                aaf = self._handle_type(v, float)
             if k == 'AN':
                 an = v
-                aaf = [float(ac_value) / float(an) for ac_value in ac]
             else:
-                an = len_samples * 2
+                an = variant.num_called*2
+            if k == 'AF':
+                aaf = self._handle_type(v, float)
+            else:
                 aaf = [float(ac_value) / float(an) for ac_value in ac]
             if variant.is_sv:
                 alt = [elem.strip("<>") for elem in variant.ALT]

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -130,9 +130,10 @@ async def test_5():
         async with session.get('http://localhost:5050/query', params=params) as resp:
             data = await resp.json()
             if 'datasetAlleleResponses' in data and len(data['datasetAlleleResponses']) > 0:
+                assert len(data['datasetAlleleResponses']) == 3, sys.exist('Should have three variants.')
                 assert data['datasetAlleleResponses'][0]['datasetId'] == 'urn:hg:1000genome', 'DatasetID Error'
                 assert data['datasetAlleleResponses'][0]['variantCount'] == 1, 'Variant count Error'
-                assert data['datasetAlleleResponses'][0]['frequency'] == 0.000197316, 'frequency Error'
+                assert data['datasetAlleleResponses'][0]['frequency'] == 0.000197472, 'frequency Error'
                 assert data['datasetAlleleResponses'][0]['exists'] is True, 'Inconsistent, exists is False, but all other pass'
             else:
                 sys.exit('Query GET Endpoint Error!')

--- a/tests/test_db_load.py
+++ b/tests/test_db_load.py
@@ -207,7 +207,7 @@ class DatabaseTestCase(asynctest.TestCase):
         db_mock.return_value = Connection()
         await self._db.connection()
         db_mock.assert_called()
-        await self._db.insert_variants('DATASET1', ['C'], 1)
+        await self._db.insert_variants('DATASET1', ['C'])
         # Should assert logs
         mock_log.info.mock_calls = [f'Received 1 variants for insertion to DATASET1',
                                     'Insert variants into the database']
@@ -235,10 +235,10 @@ class DatabaseTestCase(asynctest.TestCase):
         db_mock.return_value = Connection()
         await self._db.connection()
         variant = Variant('TC', 'T', {'AC': (1, 2), 'VT': 'M,S,I', 'AN': 3}, 0.7, 'snp', 3)
-        result = self._db._unpack(variant, 1)
+        result = self._db._unpack(variant)
         self.assertEqual(([0.3333333333333333, 0.6666666666666666], [1, 2], ['MNP', 'SNP', 'INS'], 'TC', 3), result)
         variant = Variant('TC', 'T', {'AC': 1, 'VT': 'S', 'AN': 3}, 0.7, 'snp', 3)
-        result = self._db._unpack(variant, 1)
+        result = self._db._unpack(variant)
         self.assertEqual(([0.3333333333333333], [1], ['SNP'], 'TC', 3), result)
 
     @asynctest.mock.patch('beacon_api.utils.db_load.LOG')


### PR DESCRIPTION
Remove redundant calculations and re-organise flow of variant unpacking.

EDIT: This update makes the `callCount` more precise, by no longer guesstimating it with `sampleCount`, but taking the calculated value instead.

```
# New: callCount varies

 index |           datasetid           | start | chromosome | reference  | alternate  |  end  | aggregatedvarianttype | allelecount | callcount |  frequency  | varianttype
-------+-------------------------------+-------+------------+------------+------------+-------+-----------------------+-------------+-----------+-------------+-------------
     1 | urn:hg:1000genome             |     9 | MT         | T          | C          |    10 | SNP                   |           3 |      5068 |  0.00059195 | SNP
     2 | urn:hg:1000genome             |    15 | MT         | A          | T          |    16 | SNP                   |           3 |      5068 |  0.00059195 | SNP
     3 | urn:hg:1000genome             |    25 | MT         | C          | T          |    26 | SNP                   |           3 |      5068 |  0.00059195 | SNP
     4 | urn:hg:1000genome             |    34 | MT         | G          | A          |    35 | SNP                   |           2 |      5068 | 0.000394633 | SNP
     5 | urn:hg:1000genome             |    39 | MT         | TC         | CT         |    41 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
     6 | urn:hg:1000genome             |    40 | MT         | C          | T          |    41 | SNP                   |           4 |      5068 | 0.000789266 | SNP
     7 | urn:hg:1000genome             |    41 | MT         | TCC        | CCC        |    44 | INDEL                 |           1 |      5066 | 0.000197394 | SNP
     8 | urn:hg:1000genome             |    41 | MT         | TCC        | T          |    44 | INDEL                 |           1 |      5066 | 0.000197394 | DEL
     9 | urn:hg:1000genome             |    45 | MT         | T          | C          |    46 | SNP                   |           1 |      5068 | 0.000197316 | SNP
    10 | urn:hg:1000genome             |    46 | MT         | G          | A          |    47 | SNP                   |           1 |      5068 | 0.000197316 | SNP
    11 | urn:hg:1000genome             |    51 | MT         | TGG        | CAA        |    54 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
    12 | urn:hg:1000genome             |    54 | MT         | TATTTT     | T          |    60 | INDEL                 |           5 |      5054 | 0.000989315 | DEL
    13 | urn:hg:1000genome             |    54 | MT         | TATTTT     | CATTTT     |    60 | INDEL                 |           3 |      5054 | 0.000593589 | SNP
    14 | urn:hg:1000genome             |    54 | MT         | TATTTT     | AATTTT     |    60 | INDEL                 |           2 |      5054 | 0.000395726 | SNP
    15 | urn:hg:1000genome             |    54 | MT         | TATTTT     | TTT        |    60 | INDEL                 |           1 |      5054 | 0.000197863 | DEL
    16 | urn:hg:1000genome             |    54 | MT         | TATTTT     | TTTTT      |    60 | INDEL                 |           1 |      5054 | 0.000197863 | DEL
    17 | urn:hg:1000genome             |    56 | MT         | T          | C          |    57 | SNP                   |           3 |      5068 |  0.00059195 | SNP
    18 | urn:hg:1000genome             |    57 | MT         | TTT        | T          |    60 | INDEL                 |           4 |      5068 | 0.000789266 | DEL
    19 | urn:hg:1000genome             |    58 | MT         | T          | A          |    59 | SNP                   |           1 |      5068 | 0.000197316 | SNP
    20 | urn:hg:1000genome             |    59 | MT         | T          | A          |    60 | SNP                   |           1 |      5068 | 0.000197316 | SNP
    21 | urn:hg:1000genome             |    60 | MT         | CG         | TA         |    62 | INDEL                 |           3 |      5066 | 0.000592183 | MNP
    22 | urn:hg:1000genome             |    60 | MT         | CG         | AA         |    62 | INDEL                 |           1 |      5066 | 0.000197394 | MNP
    23 | urn:hg:1000genome             |    62 | MT         | TC         | CT         |    64 | INDEL                 |           1 |      5066 | 0.000197394 | MNP
    24 | urn:hg:1000genome             |    62 | MT         | TC         | AT         |    64 | INDEL                 |           1 |      5066 | 0.000197394 | MNP
    25 | urn:hg:1000genome             |    63 | MT         | CT         | TT         |    65 | INDEL                 |         118 |      5064 |   0.0233017 | SNP
    26 | urn:hg:1000genome             |    63 | MT         | CT         | AT         |    65 | INDEL                 |           1 |      5064 | 0.000197472 | SNP
    27 | urn:hg:1000genome             |    63 | MT         | CT         | TC         |    65 | INDEL                 |           1 |      5064 | 0.000197472 | MNP
```
```
# Old: callCount is constant

  index   |     datasetid     | start | chromosome | reference  | alternate  |  end  | aggregatedvarianttype | allelecount | callcount |  frequency  | varianttype
----------+-------------------+-------+------------+------------+------------+-------+-----------------------+-------------+-----------+-------------+-------------
 81492537 | urn:hg:1000genome |     9 | MT         | T          | C          |    10 | SNP                   |           3 |      5068 |  0.00059195 | SNP
 81492538 | urn:hg:1000genome |    15 | MT         | A          | T          |    16 | SNP                   |           3 |      5068 |  0.00059195 | SNP
 81492539 | urn:hg:1000genome |    25 | MT         | C          | T          |    26 | SNP                   |           3 |      5068 |  0.00059195 | SNP
 81492540 | urn:hg:1000genome |    34 | MT         | G          | A          |    35 | SNP                   |           2 |      5068 | 0.000394633 | SNP
 81492541 | urn:hg:1000genome |    39 | MT         | TC         | CT         |    41 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
 81492542 | urn:hg:1000genome |    40 | MT         | C          | T          |    41 | SNP                   |           4 |      5068 | 0.000789266 | SNP
 81492543 | urn:hg:1000genome |    41 | MT         | TCC        | CCC        |    44 | INDEL                 |           1 |      5068 | 0.000197316 | SNP
 81492544 | urn:hg:1000genome |    41 | MT         | TCC        | T          |    44 | INDEL                 |           1 |      5068 | 0.000197316 | DEL
 81492545 | urn:hg:1000genome |    45 | MT         | T          | C          |    46 | SNP                   |           1 |      5068 | 0.000197316 | SNP
 81492546 | urn:hg:1000genome |    46 | MT         | G          | A          |    47 | SNP                   |           1 |      5068 | 0.000197316 | SNP
 81492547 | urn:hg:1000genome |    51 | MT         | TGG        | CAA        |    54 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
 81492548 | urn:hg:1000genome |    54 | MT         | TATTTT     | T          |    60 | INDEL                 |           5 |      5068 | 0.000986582 | DEL
 81492549 | urn:hg:1000genome |    54 | MT         | TATTTT     | CATTTT     |    60 | INDEL                 |           3 |      5068 |  0.00059195 | SNP
 81492550 | urn:hg:1000genome |    54 | MT         | TATTTT     | AATTTT     |    60 | INDEL                 |           2 |      5068 | 0.000394633 | SNP
 81492551 | urn:hg:1000genome |    54 | MT         | TATTTT     | TTT        |    60 | INDEL                 |           1 |      5068 | 0.000197316 | DEL
 81492552 | urn:hg:1000genome |    54 | MT         | TATTTT     | TTTTT      |    60 | INDEL                 |           1 |      5068 | 0.000197316 | DEL
 81492553 | urn:hg:1000genome |    56 | MT         | T          | C          |    57 | SNP                   |           3 |      5068 |  0.00059195 | SNP
 81492554 | urn:hg:1000genome |    57 | MT         | TTT        | T          |    60 | INDEL                 |           4 |      5068 | 0.000789266 | DEL
 81492555 | urn:hg:1000genome |    58 | MT         | T          | A          |    59 | SNP                   |           1 |      5068 | 0.000197316 | SNP
 81492556 | urn:hg:1000genome |    59 | MT         | T          | A          |    60 | SNP                   |           1 |      5068 | 0.000197316 | SNP
 81492557 | urn:hg:1000genome |    60 | MT         | CG         | TA         |    62 | INDEL                 |           3 |      5068 |  0.00059195 | MNP
 81492558 | urn:hg:1000genome |    60 | MT         | CG         | AA         |    62 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
 81492559 | urn:hg:1000genome |    62 | MT         | TC         | CT         |    64 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
 81492560 | urn:hg:1000genome |    62 | MT         | TC         | AT         |    64 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
 81492561 | urn:hg:1000genome |    63 | MT         | CT         | TT         |    65 | INDEL                 |         118 |      5068 |   0.0232833 | SNP
 81492562 | urn:hg:1000genome |    63 | MT         | CT         | AT         |    65 | INDEL                 |           1 |      5068 | 0.000197316 | SNP
 81492563 | urn:hg:1000genome |    63 | MT         | CT         | TC         |    65 | INDEL                 |           1 |      5068 | 0.000197316 | MNP
```