### PR TITLE
Fix typos and dated information in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We have templates for submitting new issues, that you can fill out. For example 
 
 ### Submitting changes
 
-When you made some changes you are happy with please send a [GitHub Pull Request to beacon-python](https://github.com/CSCfi/beacon-python/pull/new/master) with a clear list of what you've done (read more about [pull requests](https://help.github.com/en/articles/about-pull-requests)). When you create that Pull Request, we will forever be in your debt if you include unit tests. For extra bonus points you can always use add some more integration test. 
+When you made some changes you are happy with please send a [GitHub Pull Request to beacon-python](https://github.com/CSCfi/beacon-python/pull/new/master) with a clear list of what you've done (read more about [pull requests](https://help.github.com/en/articles/about-pull-requests)). When you create that Pull Request, we will forever be in your debt if you include unit tests. For extra bonus points you can always use add some more integration tests.
 
 Please follow our Git branches model and coding conventions (both below), and make sure all of your commits are atomic (preferably one feature per commit) and it is recommended a Pull Request addresses one functionality or fixes one bug.
 
@@ -27,11 +27,11 @@ Once submitted, the Pull Request will go through a review process, meaning we wi
 
 Give your branch a short descriptive name (like the names between the `<>` below) and prefix the name with something representative for that branch:
 
-   * `feature/<feature-name>` - used when an enhancement or new feature implemented;
-   * `docs/<what-the-docs>` - missing docs or making them up to date;
+   * `feature/<feature-name>` - used when an enhancement or new feature was implemented;
+   * `docs/<what-the-docs>` - missing docs or keeping them up to date;
    * `bugfix/<caught-it>` - solved a bug;
    * `test/<thank-you>` - adding missing tests for a feature, we would prefer they would come with the `feature` but still `thank you`;
-   * `refactor/<that-name-is-confusing>` - well we hope we don't mess anything and we don't use this;
+   * `refactor/<that-name-is-confusing>` - well we hope we don't mess anything and we don't get to use this;
    * `hotfix/<oh-no>` - for when things needed to be fixed yesterday.
 
 

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -32,7 +32,7 @@ Using OpenShift's ``s2i`` means of building the Docker image requires
     $ s2i build . centos/python-36-centos7 cscfi/beacon-python
 
 After the image has been built one can use it with the simple Docker ``run``
-(requires connection to a connection to a DB in the same docker network)
+(requires connection to a DB in the same docker network)
 or as part of a docker-compose file or as illustrated below with Kubernetes.
 
 .. code-block:: console

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -42,9 +42,9 @@ Example Response:
         "welcomeUrl": "https://www.csc.fi/",
         "contactUrl": "https://www.csc.fi/contact-info",
         "logoUrl": "https://www.csc.fi/documents/10180/161914/CSC_2012_LOGO_RGB_72dpi.jpg",
-        "info": [{
+        "info": {
           "orgInfo": "CSC represents Finland in the ELIXIR partner nodes"
-        }]
+        }
       },
       "description": "Beacon API Web Server based on the GA4GH Beacon API",
       "version": "1.0.0",
@@ -62,9 +62,9 @@ Example Response:
         "callCount": 79423363,
         "sampleCount": 2504,
         "version": "v0.4",
-        "info": [{
+        "info": {
           "accessType": "PUBLIC"
-        }],
+        },
         "createDateTime": "2013-05-02T12:00:00Z",
         "updateDateTime": "2013-05-02T12:00:00Z"
       }],
@@ -72,22 +72,22 @@ Example Response:
         "alternateBases": "C",
         "referenceBases": "T",
         "referenceName": "MT",
-        "start": 10,
+        "start": 9,
         "assemblyId": "GRCh38",
         "includeDatasetResponses": "ALL"
       }, {
         "alternateBases": "A",
         "referenceBases": "G",
         "referenceName": "MT",
-        "start": 7600,
+        "start": 7599,
         "assemblyId": "GRCh38",
         "datasetIds": ["urn:hg:exampleid-mt"],
         "includeDatasetResponses": "HIT"
       }, {
         "variantType": "SNP",
-        "referenceBases": "T",
+        "referenceBases": "G",
         "referenceName": "Y",
-        "start": 7267244,
+        "start": 7267243,
         "assemblyId": "GRCh38"
       }],
       "info": {
@@ -103,7 +103,7 @@ An example ``GET`` request and response to the ``query`` endpoint:
 .. code-block:: console
 
     $ curl -X GET \
-      'http://localhost:5050/query?referenceName=MT&referenceBases=A&start=14037&assemblyId=GRCh38&alternateBases=G'
+      'http://localhost:5050/query?referenceName=MT&referenceBases=A&start=14036&assemblyId=GRCh38&alternateBases=G'
 
 Example Response:
 
@@ -115,7 +115,7 @@ Example Response:
       "exists": true,
       "alleleRequest": {
         "referenceName": "MT",
-        "start": 14037,
+        "start": 14036,
         "referenceBases": "A",
         "assemblyId": "GRCh38",
         "datasetIds": [],
@@ -133,7 +133,7 @@ An example ``POST`` request and response to the ``query`` endpoint:
     $ curl -X POST \
       'http://localhost:5050/query' \
       -d '{"referenceName": "MT", \
-      "start": 14037, \
+      "start": 14036, \
       "referenceBases": "A", \
       "alternateBases": "G", \
       "assemblyId": "GRCh38", \
@@ -149,7 +149,7 @@ Example Response:
       "exists": true,
       "alleleRequest": {
         "referenceName": "MT",
-        "start": 14037,
+        "start": 14036,
         "referenceBases": "A",
         "assemblyId": "GRCh38",
         "datasetIds": [],

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -71,7 +71,7 @@ Example testing with `locust.io <http://locust.io/>`_
     @task
     def get_query(self):
         """Test GET query endpoint."""
-        self.client.get("/query?assemblyId=GRCh38&referenceName=MT&start=10&referenceBases=T&alternateBases=C&includeDatasetResponses=HIT")
+        self.client.get("/query?assemblyId=GRCh38&referenceName=MT&start=9&referenceBases=T&alternateBases=C&includeDatasetResponses=HIT")
 
 
     class APITest(HttpLocust):


### PR DESCRIPTION
# Exterminate Typos
![image](https://user-images.githubusercontent.com/17040963/54339554-da3eaa00-463d-11e9-95fe-7e425fca5e61.png)

### Description

Found dated information and typos from the docs.

### Changes Made

Corrected outdated information and fixed some typos in `docs/`
- `deploy.rst`
- `example.rst`
- `testing.rst`

### Testing

- [x] Tests do not apply
