### PR TITLE
Add coordinates to response

### DIFF
--- a/beacon_api/schemas/response.json
+++ b/beacon_api/schemas/response.json
@@ -137,6 +137,12 @@
             "type": "string",
             "pattern": "^([ACGT]+)$"
           },
+          "start": {
+            "type": "integer"
+          },
+          "end": {
+            "type": "integer"
+          },
           "variantType": {
             "type": "string",
             "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME"]

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -13,6 +13,8 @@ def transform_record(record):
     response["referenceBases"] = response.pop("referenceBases")  # NOT part of beacon specification
     response["alternateBases"] = response.pop("alternateBases")  # NOT part of beacon specification
     response["variantType"] = response.pop("variantType")  # NOT part of beacon specification
+    response["start"] = response.pop("start")  # NOT part of beacon specification
+    response["end"] = response.pop("end")  # NOT part of beacon specification
     response["frequency"] = round(response.pop("frequency"), 9)
     response["info"] = {"accessType": response.pop("accessType")}
     # Error is not required and should not be shown unless exists is null
@@ -29,6 +31,8 @@ def transform_misses(record):
     response["referenceBases"] = ''  # NOT part of beacon specification
     response["alternateBases"] = ''  # NOT part of beacon specification
     response["variantType"] = ''  # NOT part of beacon specification
+    response["start"] = 0  # NOT part of beacon specification
+    response["end"] = 0  # NOT part of beacon specification
     response["frequency"] = 0
     response["variantCount"] = 0
     response["callCount"] = 0
@@ -150,8 +154,9 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
 
                 # UBER QUERY - TBD if it is what we need
                 # referenceBases, alternateBases and variantType fields are NOT part of beacon specification example response
-                query = f"""SELECT {"DISTINCT ON (a.datasetId)" if misses else ''} a.datasetId as "datasetId", b.accessType as "accessType",
-                            a.chromosome as "referenceName", a.reference as "referenceBases", a.alternate as "alternateBases",
+                query = f"""SELECT {"DISTINCT ON (a.datasetId)" if misses else ''}
+                            a.datasetId as "datasetId", b.accessType as "accessType", a.chromosome as "referenceName",
+                            a.reference as "referenceBases", a.alternate as "alternateBases", a.start as "start", a.end as "end",
                             b.externalUrl as "externalUrl", b.description as "note",
                             a.alleleCount as "variantCount", a.variantType as "variantType",
                             a.callCount as "callCount", b.sampleCount as "sampleCount",

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -70,6 +70,8 @@ async def test_2():
                 assert data['datasetAlleleResponses'][0]['datasetId'] == 'urn:hg:1000genome', 'DatasetID Error'
                 assert data['datasetAlleleResponses'][0]['variantCount'] == 3, 'Variant count Error'
                 assert data['datasetAlleleResponses'][0]['frequency'] == 0.00059195, 'frequency Error'
+                assert data['datasetAlleleResponses'][0]['start'] == 9, 'Start coordinate Error'
+                assert data['datasetAlleleResponses'][0]['end'] == 10, 'End coordinate Error'
                 assert data['datasetAlleleResponses'][0]['exists'] is True, 'Inconsistent, exists is False, but all other pass'
             else:
                 sys.exit('Query GET Endpoint Error!')
@@ -159,6 +161,8 @@ async def test_6():
                 assert data['datasetAlleleResponses'][0]['datasetId'] == 'urn:hg:1000genome', 'DatasetID Error'
                 assert data['datasetAlleleResponses'][0]['variantCount'] == 3, 'Variant count Error'
                 assert data['datasetAlleleResponses'][0]['frequency'] == 0.00059195, 'frequency Error'
+                assert data['datasetAlleleResponses'][0]['start'] == 9, 'Start coordinate Error'
+                assert data['datasetAlleleResponses'][0]['end'] == 10, 'End coordinate Error'
                 assert data['datasetAlleleResponses'][0]['exists'] is True, 'Inconsistent, exists is False, but all other pass'
             else:
                 sys.exit('Query POST Endpoint Error!')

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -105,7 +105,7 @@ An example ``GET`` request and response to the ``query`` endpoint:
     $ curl -X GET \
       'http://localhost:5050/query?referenceName=MT&referenceBases=A&start=14036&assemblyId=GRCh38&alternateBases=G'
 
-Example Response:
+Example Request:
 
 .. code-block:: javascript
 
@@ -166,6 +166,8 @@ Example Response:
         "exists": true,
         "referenceBases": "A",
         "alternateBases": "G",
+        "start": 14036,
+        "end": 14037,
         "variantType": "SNP",
         "frequency": 0.000789266,
         "variantCount": 1,

--- a/tests/test_data_query.py
+++ b/tests/test_data_query.py
@@ -14,7 +14,8 @@ class Record:
     """
 
     def __init__(self, accessType, frequency=None, createDateTime=None, updateDateTime=None,
-                 referenceBases=None, alternateBases=None, variantCount=0, variantType=None):
+                 referenceBases=None, alternateBases=None, start=None, end=None,
+                 variantCount=0, variantType=None):
         """Initialise things."""
         self.data = {"accessType": accessType}
         # self.variantCount = variantCount
@@ -26,6 +27,10 @@ class Record:
             self.data.update({"alternateBases": alternateBases})
         if variantType:
             self.data.update({"variantType": variantType})
+        if start:
+            self.data.update({"start": start})
+        if end:
+            self.data.update({"end": end})
         if frequency:
             self.data.update({"frequency": frequency})
         if createDateTime:
@@ -80,8 +85,10 @@ class TestDataQueryFunctions(asynctest.TestCase):
     def test_transform_record(self):
         """Test transform DB record."""
         response = {"frequency": 0.009112876, "info": {"accessType": "PUBLIC"},
-                    "referenceBases": "CT", "alternateBases": "AT", "variantCount": 3, "variantType": "MNP"}
-        record = Record("PUBLIC", 0.009112875989879, referenceBases="CT", alternateBases="AT", variantCount=3, variantType="MNP")
+                    "referenceBases": "CT", "alternateBases": "AT",
+                    "start": 10, "end": 12,
+                    "variantCount": 3, "variantType": "MNP"}
+        record = Record("PUBLIC", 0.009112875989879, referenceBases="CT", alternateBases="AT", start=10, end=12, variantCount=3, variantType="MNP")
         result = transform_record(record)
         self.assertEqual(result, response)
 
@@ -89,7 +96,7 @@ class TestDataQueryFunctions(asynctest.TestCase):
         """Test transform misses record."""
         response = {"referenceBases": '', "alternateBases": '', "variantType": "",
                     "frequency": 0, "callCount": 0, "sampleCount": 0, "variantCount": 0,
-                    "info": {"accessType": "PUBLIC"}}
+                    "start": 0, "end": 0, "info": {"accessType": "PUBLIC"}}
         record = Record("PUBLIC")
         result = transform_misses(record)
         self.assertEqual(result, response)


### PR DESCRIPTION
# Coordinates in response

### Description

Adds `start` and `end` coordinates to `datasetAlleleResponses` to help with identifying relevant regions from queries made with fuzzy boundaries (`startMin`, `startMax`, `endMin`, `endMax`).

### Related issues

Fixes #77 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

* Added new fields to json schema;
* Added fetching of new fields from database;
* Updated response body to include new fields;
* Updated unit tests to verify handling of new fields;
* Updated a couple of integration tests to verify that new fields return correct information;
* Updated documentation.

### Testing

- [x] Unit Tests
- [x] Integration Tests
