### PR TITLE
Fix callCount

### DIFF
--- a/data/init.sql
+++ b/data/init.sql
@@ -18,8 +18,8 @@ The values in this table take a long time to compute on large datasets
 Most likely these values do not change once the dataset is loaded so one
 could compute the values and UPDATE the table once the all dataset is inserted
 
-callcount: SELECT count(*) FROM (SELECT distinct(reference, start)
-                                FROM beacon_data_table) t;
+callcount: SELECT count(*) FROM (SELECT distinct(datasetId, chromosome, reference, start)
+                                 FROM beacon_data_table) t;
 
 variantcount: SELECT count(*) FROM beacon_data_table;
 */


### PR DESCRIPTION
# Fix callCount
### Description

`callCount` in the SQL comments was counted erroneously. It didn't take into account different chromosomes (nor different datasets) with same variant locations.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

Small bug fix to `init.sql`.

### Testing

- [x] Tests do not apply

### Mentions
Bug reported by @MalinAhlberg 
