### PR TITLE
Adding support for mateName 

### DIFF
--- a/beacon_api/api/query.py
+++ b/beacon_api/api/query.py
@@ -9,6 +9,7 @@ from ..utils.logging import LOG
 from .. import __apiVersion__, __handover_beacon__, __handover_drs__
 from ..utils.data_query import filter_exists, find_datasets, fetch_datasets_access
 from ..extensions.handover import make_handover
+from ..extensions.mate_name import find_fusion
 from .exceptions import BeaconUnauthorised, BeaconForbidden, BeaconBadRequest
 
 
@@ -100,9 +101,14 @@ async def query_request_handler(params):
     public_datasets, registered_datasets, controlled_datasets = await fetch_datasets_access(params[0], request.get("datasetIds"))
     access_type, accessible_datasets = access_resolution(request, params[3], params[4], public_datasets,
                                                          registered_datasets, controlled_datasets)
-    datasets = await find_datasets(params[0], request.get("assemblyId"), requested_position, request.get("referenceName"),
-                                   request.get("referenceBases"), alternate,
-                                   accessible_datasets, access_type, request.get("includeDatasetResponses", "NONE"))
+    if 'mateName' in request or alleleRequest.get('variantType') == 'BND':
+        datasets = await find_fusion(params[0], request.get("assemblyId"), requested_position, request.get("referenceName"),
+                                     request.get("referenceBases"), request.get('mateName'),
+                                     accessible_datasets, access_type, request.get("includeDatasetResponses", "NONE"))
+    else:
+        datasets = await find_datasets(params[0], request.get("assemblyId"), requested_position, request.get("referenceName"),
+                                       request.get("referenceBases"), alternate,
+                                       accessible_datasets, access_type, request.get("includeDatasetResponses", "NONE"))
 
     beacon_response = {'beaconId': '.'.join(reversed(params[4].split('.'))),
                        'apiVersion': __apiVersion__,

--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -7,7 +7,7 @@
 title=GA4GHBeacon at CSC
 
 # Version of the Beacon implementation
-version=1.1.0
+version=1.2.0
 
 # Author of this software
 author=CSC developers
@@ -21,7 +21,7 @@ copyright=CSC - IT Center for Science
 
 [beacon_api_info]
 # Version of the Beacon API specification this implementation adheres to
-apiVersion=1.0.1
+apiVersion=1.1.0
 
 # Globally unique identifier for this Beacon instance
 beaconId=fi.csc.beacon

--- a/beacon_api/extensions/__init__.py
+++ b/beacon_api/extensions/__init__.py
@@ -1,7 +1,7 @@
 """Extensions Module.
 
 This module contains optional extensions to the Beacon Python Server.
-Currently we have to extensions:
+Currently we have two extensions:
 
 * handover - used to convey extra information regarding the Beacon service, or the dataset response;
 * mate fusion - used for finding breakend records.

--- a/beacon_api/extensions/__init__.py
+++ b/beacon_api/extensions/__init__.py
@@ -1,1 +1,8 @@
-"""Extension Module."""
+"""Extensions Module.
+
+This module contains optional extenstions to the Beacon Python Server.
+Currently we have to extensions:
+
+* handover - used to convey extra information regarding the Beacon service, or the dataset response;
+* mate fusion - used for finding breakend records
+"""

--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -12,7 +12,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                                datasets=None, access_type=None, misses=False):
     """Execute filter datasets.
 
-    There is an Uber query that aims to be all inclusive yet specific for mate fusion table.
+    There is an Uber query that aims to retrieve specific for data for mate fusion table.
     """
     # Take one connection from the database pool
     async with db_pool.acquire(timeout=180) as connection:

--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -1,0 +1,92 @@
+"""Prepare mate."""
+from functools import partial
+from ..utils.logging import LOG
+from ..api.exceptions import BeaconServerError
+from ..conf.config import DB_SCHEMA
+from .handover import add_handover
+from ..utils.data_query import handle_wildcard, transform_misses, transform_record
+from .. import __handover_drs__
+
+
+async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, reference, mate,
+                                 datasets=None, access_type=None, misses=False):
+    """Execute filter datasets.
+
+    There is an Uber query that aims to be all inclusive yet specific for mate fusion table.
+    """
+    # Take one connection from the database pool
+    async with db_pool.acquire(timeout=180) as connection:
+        # Start a new session with the connection
+        async with connection.transaction():
+            # Fetch dataset metadata according to user request
+            datasets_query = None if not datasets else datasets
+            access_query = None if not access_type else access_type
+
+            start_pos = None if position[0] is None or (position[2] and position[3]) else position[0]
+            end_pos = None if position[1] is None or (position[4] and position[5]) else position[1]
+            startMax_pos = position[3]
+            startMin_pos = position[2]
+            endMin_pos = position[4]
+            endMax_pos = position[5]
+
+            refbase = None if not reference else handle_wildcard(reference)
+            print(refbase)
+            try:
+
+                # UBER QUERY - TBD if it is what we need
+                # referenceBases, alternateBases and variantType fields are NOT part of beacon's specification response
+                query = f"""SELECT {"DISTINCT ON (a.datasetId)" if misses else ''}
+                            a.datasetId as "datasetId", b.accessType as "accessType", a.chromosome as "referenceName",
+                            a.reference as "referenceBases", a.alternate as "alternateBases", a.chromosomeStart as "start",
+                            a.mate as "mateName",
+                            a.chromosomePos as "referenceID", a.matePos as "mateID", a.mateStart as "mateStart", a.end as "end",
+                            b.externalUrl as "externalUrl", b.description as "note",
+                            a.alleleCount as "variantCount", CAST('BND' as text) as "variantType",
+                            a.callCount as "callCount", b.sampleCount as "sampleCount",
+                            a.frequency, {"FALSE" if misses else "TRUE"} as "exists"
+                            FROM {DB_SCHEMA}beacon_mate_table a, {DB_SCHEMA}beacon_dataset_table b
+                            WHERE a.datasetId=b.datasetId
+                            AND b.assemblyId=$3
+                            AND a.mate=$5
+                            AND a.chromosome=$4
+                            AND coalesce(a.reference LIKE any($6::varchar[]), true)
+                            AND {"NOT" if misses else ''} (coalesce(a.chromosomeStart=$7, true)
+                            AND coalesce(a.mateStart=$8, true)
+                            AND coalesce(a.chromosomeStart<=$9, true) AND coalesce(a.chromosomeStart>=$10, true)
+                            AND coalesce(a.mateStart>=$11, true) AND coalesce(a.mateStart<=$12, true))
+                            AND coalesce(b.accessType = any($2::varchar[]), true)
+                            {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), true) ;"""
+                datasets = []
+                statement = await connection.prepare(query)
+                db_response = await statement.fetch(datasets_query, access_query, assembly_id, chromosome,
+                                                    mate, refbase,
+                                                    start_pos, end_pos,
+                                                    startMax_pos, startMin_pos,
+                                                    endMin_pos, endMax_pos)
+                LOG.info(f"Query for dataset(s): {datasets} that are {access_type} matching conditions.")
+                for record in list(db_response):
+                    processed = transform_misses(record) if misses else transform_record(record)
+                    if __handover_drs__:
+                        # If handover feature is enabled, add handover object to response
+                        processed = add_handover(processed)
+                    datasets.append(processed)
+                return datasets
+            except Exception as e:
+                raise BeaconServerError(f'Query dataset DB error: {e}')
+
+
+async def find_fusion(db_pool, assembly_id, position, chromosome, reference, mate, dataset_ids, access_type, include_dataset):
+    """Find datasets based on filter parameters.
+
+    This also takes into consideration the token value as to establish permissions.
+    """
+    hit_datasets = []
+    miss_datasets = []
+    response = []
+    fetch_call = partial(fetch_filtered_dataset, db_pool, assembly_id, position, chromosome, reference, mate)
+    hit_datasets = await fetch_call(dataset_ids, access_type)
+    if include_dataset in ['ALL', 'MISS']:
+        miss_datasets = await fetch_call([item["datasetId"] for item in hit_datasets], access_type, misses=True)
+
+    response = hit_datasets + miss_datasets
+    return response

--- a/beacon_api/schemas/info.json
+++ b/beacon_api/schemas/info.json
@@ -805,7 +805,7 @@
           },
           "variantType": {
             "type": "string",
-            "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME"]
+            "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME", "BND"]
           },
           "assemblyId": {
             "type": "string",
@@ -828,33 +828,33 @@
       "type": "object"
     },
     "beaconHandover": {
-            "type": "array",
-            "required": [
-              "handoverType",
-              "url"
-            ],
-            "properties": {
-              "handoverType": {
-                "type": "object",
-                "required": [
-                  "id"
-                ],
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "label": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": {
-                    "type": "string"
-              },
-              "url": {
-                    "type": "string"
-              }
+      "type": "array",
+      "required": [
+        "handoverType",
+        "url"
+      ],
+      "properties": {
+        "handoverType": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
             }
+          }
+        },
+        "description": {
+              "type": "string"
+        },
+        "url": {
+              "type": "string"
+        }
+      }
     }
   }
 }

--- a/beacon_api/schemas/query.json
+++ b/beacon_api/schemas/query.json
@@ -14,6 +14,12 @@
         "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y", "MT"
       ]
     },
+    "mateName": {
+      "type": "string",
+      "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
+        "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y", "MT"
+      ]
+    },
     "start": {
       "type": "integer",
       "minimum": 0
@@ -48,7 +54,7 @@
     },
     "variantType": {
       "type": "string",
-      "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME"]
+      "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME", "BND"]
     },
     "assemblyId": {
       "type": "string",
@@ -60,7 +66,7 @@
       "items": {
         "type": "string",
         "default": "none",
-        "pattern": "^(.*)$"
+        "pattern": "^[^<>'\"/;`%{}+=]*$"
       }
     },
     "includeDatasetResponses": {
@@ -80,7 +86,22 @@
       "endMax"
     ],
     "startMax": ["startMin"],
-    "endMax": ["endMin"]
+    "endMax": ["endMin"],
+    "mateName": {
+      "oneOf": [{
+        "required": [
+          "start",
+          "end"
+        ]
+      },
+      {
+        "required": [
+          "startMin",
+          "endMin"
+        ]
+      }
+    ]
+    }
   },
   "allOf": [{
     "oneOf": [{
@@ -91,6 +112,11 @@
       {
         "required": [
           "alternateBases"
+        ]
+      },
+      {
+        "required": [
+          "mateName"
         ]
       }
     ]
@@ -119,7 +145,7 @@
           },
           {
             "required": [
-              "endMin"
+              "endMax"
             ]
           }
         ]

--- a/beacon_api/schemas/response.json
+++ b/beacon_api/schemas/response.json
@@ -43,6 +43,12 @@
             }
           ]
         },
+        "mateName": {
+          "type": "string",
+          "enum": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12",
+            "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y", "MT"
+          ]
+        },
         "start": {
           "type": "integer",
           "minimum": 0
@@ -83,7 +89,7 @@
         },
         "variantType": {
           "type": "string",
-          "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME"]
+          "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME", "BND"]
         },
         "assemblyId": {
           "oneOf": [{
@@ -99,7 +105,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^(.*)$"
+            "pattern": "^[^<>'\"/;`%{}+=]*$"
           }
         },
         "includeDatasetResponses": {
@@ -109,33 +115,33 @@
       }
     },
     "beaconHandover": {
-            "type": "array",
-            "required": [
-              "handoverType",
-              "url"
-            ],
-            "properties": {
-              "handoverType": {
-                "type": "object",
-                "required": [
-                  "id"
-                ],
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "label": {
-                    "type": "string"
-                  }
-                }
-              },
-              "description": {
-                    "type": "string"
-              },
-              "url": {
-                    "type": "string"
-              }
+      "type": "array",
+      "required": [
+        "handoverType",
+        "url"
+      ],
+      "properties": {
+        "handoverType": {
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
             }
+          }
+        },
+        "description": {
+              "type": "string"
+        },
+        "url": {
+              "type": "string"
+        }
+      }
     },
     "datasetAlleleResponses": {
       "type": "array",
@@ -203,7 +209,7 @@
           },
           "variantType": {
             "type": "string",
-            "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME"]
+            "enum": ["DEL", "INS", "DUP", "INV", "CNV", "SNP", "MNP", "DUP:TANDEM", "DEL:ME", "INS:ME", "BND"]
           },
           "error": {
             "type": "object",

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -18,6 +18,7 @@ def transform_record(record):
     response["start"] = response.pop("start")  # NOT part of beacon specification
     response["end"] = response.pop("end")  # NOT part of beacon specification
     response["frequency"] = 0 if response.get("frequency") is None else round(response.pop("frequency"), 9)
+    response["variantCount"] = 0 if response.get("variantCount") is None else response.get("variantCount")
     response["info"] = {"accessType": response.pop("accessType")}
     # Error is not required and should not be shown unless exists is null
     # If error key is set to null it will still not validate as it has a required key errorCode

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -17,7 +17,7 @@ def transform_record(record):
     response["variantType"] = response.pop("variantType")  # NOT part of beacon specification
     response["start"] = response.pop("start")  # NOT part of beacon specification
     response["end"] = response.pop("end")  # NOT part of beacon specification
-    response["frequency"] = round(response.pop("frequency"), 9)
+    response["frequency"] = 0 if response.get("frequency") is None else round(response.pop("frequency"), 9)
     response["info"] = {"accessType": response.pop("accessType")}
     # Error is not required and should not be shown unless exists is null
     # If error key is set to null it will still not validate as it has a required key errorCode

--- a/data/init.sql
+++ b/data/init.sql
@@ -46,8 +46,28 @@ CREATE TABLE IF NOT EXISTS beacon_data_table (
     PRIMARY KEY (index)
 );
 
+CREATE TABLE IF NOT EXISTS beacon_mate_table (
+    index SERIAL,
+    datasetId VARCHAR(128),
+    chromosome VARCHAR(2), 
+    chromosomeStart INTEGER,
+    chromosomePos VARCHAR(128), /*for working with MATEID*/
+    mate VARCHAR(2), 
+    mateStart INTEGER,
+    matePos VARCHAR(128), /*for working with MATEID*/
+    reference VARCHAR(8192),
+    alternate VARCHAR(8192),
+    alleleCount INTEGER,
+    callCount INTEGER,
+    frequency REAL,
+    "end" INTEGER,
+    PRIMARY KEY (index)
+);
+
 CREATE UNIQUE INDEX data_conflict ON beacon_data_table (datasetId, chromosome, start, reference, alternate);
 CREATE UNIQUE INDEX metadata_conflict ON beacon_dataset_table (name, datasetId);
+CREATE UNIQUE INDEX mate_conflict ON beacon_mate_table (datasetId, chromosome, mate, chromosomePos, matePos);
+
 
 CREATE OR REPLACE VIEW dataset_metadata(name, datasetId, description, assemblyId,
                                         createDateTime, updateDateTime, version,

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -94,6 +94,7 @@ Extensions
    :toctree: beacon_api.extensions
 
     beacon_api.extensions.handover
+    beacon_api.extensions.mate_name
 
 
 :ref:`genindex` | :ref:`modindex`

--- a/docs/db.rst
+++ b/docs/db.rst
@@ -40,7 +40,7 @@ using one of the solutions:
 
 .. literalinclude:: /../data/init.sql
    :language: sql
-   :lines: 1-62
+   :lines: 1-82
 
 .. note:: In order to retrieve bot HIT and MISS (according) to the API specification,
           we make use of the same query structure, exemplified below.

--- a/docs/optionals.rst
+++ b/docs/optionals.rst
@@ -49,5 +49,129 @@ Taking the first line from ``dataset_paths`` as an example, produces an object i
 MateName Fusions
 ----------------
 
-TBD
+This extension deals with processing ``SVTYPE=BND`` where each adjacency ties together
+2 breakends. Refer to Page 20 of the `VCF documentation <https://samtools.github.io/hts-specs/VCFv4.3.pdf>`_
+for more information.
+
++-------+----------+------------------------------------------------------------+
+| REF   | ALT      | Meaning                                                    |
++-------+----------+------------------------------------------------------------+
+| s     | ``t[p[`` | piece extending to the right of p is joined after t        |
++-------+----------+------------------------------------------------------------+
+| s     | ``t]p]`` | reverse comp piece extending left of p is joined after t   |
++-------+----------+------------------------------------------------------------+
+| s     | ``]p]t`` |  piece extending to the left of p is joined before t       |
++-------+----------+------------------------------------------------------------+
+| s     | ``[p[t`` | reverse comp piece extending right of p is joined before t |
++-------+----------+------------------------------------------------------------+
+
+
+.. note:: Where ``p`` is ``chr:pos``.
+
+Example queries:
+
+.. code-block:: console
+
+    localhost:5050/query?referenceName=1&\
+                        referenceBases=N&\
+                        start=108796059&\
+                        assemblyId=GRCh38&\
+                        variantType=BND&\
+                        end=121482216&\
+                        datasetIds=urn:hg:1000genome&\
+                        includeDatasetResponses=HIT
+
+    localhost:5050/query?referenceName=1&\
+                         referenceBases=N&\
+                         start=108796059&\
+                         assemblyId=GRCh38&\
+                         mateName=10&\
+                         end=121482216&\
+                         datasetIds=urn:hg:1000genome&\
+                         includeDatasetResponses=HIT
+
+    localhost:5050/query?referenceName=1&\
+                         referenceBases=N&\
+                         startMin=108796058&\
+                         startMax=108796059&\
+                         assemblyId=GRCh38&\
+                         mateName=10&\
+                         endMin=121482215&\
+                         endMax=121482216&\
+                         datasetIds=urn:hg:1000genome&\
+                         includeDatasetResponses=HIT
+
+
+Currently querying for a ``BND`` using ``startMin``, ``startMax`` and ``endMin``, ``endMax``
+with ``variantType=BND`` has the response illustrated below.
+Fixed ``start`` and ``end`` can be utilised, as well as ``mateName`` as depicted above.
+
+.. code-block:: javascript
+
+    {
+    "beaconId": "localhost:5050",
+    "apiVersion": "1.1.0",
+    "exists": true,
+    "alleleRequest": {
+        "referenceName": "1",
+        "referenceBases": "N",
+        "assemblyId": "GRCh38",
+        "includeDatasetResponses": "HIT",
+        "datasetIds": [
+            "urn:hg:1000genome"
+        ],
+        "startMin": 108796058,
+        "startMax": 108796059,
+        "endMin": 121482215,
+        "endMax": 121482216
+    },
+    "datasetAlleleResponses": [
+        {
+            "datasetId": "urn:hg:1000genome",
+            "referenceName": "1",
+            "mateName": "10",
+            "referenceID": "137_1",
+            "mateID": "137_2",
+            "mateStart": 121482216,
+            "externalUrl": "ftp://example",
+            "note": "Data",
+            "variantCount": 0,
+            "callCount": 0,
+            "sampleCount": 1,
+            "frequency": 0,
+            "exists": true,
+            "referenceBases": "N",
+            "alternateBases": "N[CHR10:121482216[",
+            "variantType": "BND",
+            "start": 108796058,
+            "end": 108796059,
+            "info": {
+                "accessType": "PUBLIC"
+            }
+        },
+        {
+            "datasetId": "urn:hg:1000genome",
+            "referenceName": "10",
+            "mateName": "1",
+            "referenceID": "137_2",
+            "mateID": "137_1",
+            "mateStart": 108796059,
+            "externalUrl": "ftp://example",
+            "note": "Data",
+            "variantCount": 0,
+            "callCount": 0,
+            "sampleCount": 1,
+            "frequency": 0,
+            "exists": true,
+            "referenceBases": "N",
+            "alternateBases": "]CHR1:108796059]N",
+            "variantType": "BND",
+            "start": 121482215,
+            "end": 121482216,
+            "info": {
+                "accessType": "PUBLIC"
+            }
+        }
+    ]
+    }
 

--- a/docs/optionals.rst
+++ b/docs/optionals.rst
@@ -43,3 +43,9 @@ Taking the first line from ``dataset_paths`` as an example, produces an object i
             }
         ]
     }
+
+.. _mate-name:
+
+MateName Fusions
+----------------
+

--- a/docs/optionals.rst
+++ b/docs/optionals.rst
@@ -1,7 +1,7 @@
 Optional Features
 =================
 
-The Beacon specification contains some optional features that may be present or not.
+The Beacon specification contains some optional features that may be utilised or not.
 
 .. _handover-protocol:
 
@@ -48,4 +48,6 @@ Taking the first line from ``dataset_paths`` as an example, produces an object i
 
 MateName Fusions
 ----------------
+
+TBD
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='beacon_api',
           'Programming Language :: Python :: 3.6',
       ],
       install_requires=['aiohttp', 'asyncpg', 'python-jose[cryptography]',
-                        'jsonschema==3.0.0', 'gunicorn'],
+                        'jsonschema==3.0.1', 'gunicorn'],
       extras_require={
           'test': ['coverage', 'pytest', 'pytest-cov',
                    'coveralls', 'testfixtures', 'tox',

--- a/tests/test_db_load.py
+++ b/tests/test_db_load.py
@@ -147,6 +147,14 @@ class DatabaseTestCase(asynctest.TestCase):
         self._dir.cleanup_all()
 
     @asynctest.mock.patch('beacon_api.utils.db_load.asyncpg.connect')
+    async def test_rchop(self, db_mock):
+        """Test breakend parsing parts."""
+        db_mock.return_value = Connection()
+        await self._db.connection()
+        result = self._db._rchop('INS:ME:LINE1', ":LINE1")
+        self.assertEqual('INS:ME', result)
+
+    @asynctest.mock.patch('beacon_api.utils.db_load.asyncpg.connect')
     async def test_bnd_parts(self, db_mock):
         """Test breakend parsing parts."""
         db_mock.return_value = Connection()

--- a/tests/test_db_load.py
+++ b/tests/test_db_load.py
@@ -154,7 +154,7 @@ class DatabaseTestCase(asynctest.TestCase):
 
     @asynctest.mock.patch('beacon_api.utils.db_load.asyncpg.connect')
     async def test_rchop(self, db_mock):
-        """Test breakend parsing parts."""
+        """Test rchop for SVTYPE."""
         db_mock.return_value = Connection()
         await self._db.connection()
         result = self._db._rchop('INS:ME:LINE1', ":LINE1")

--- a/tests/test_db_load.py
+++ b/tests/test_db_load.py
@@ -146,6 +146,14 @@ class DatabaseTestCase(asynctest.TestCase):
         """Close database connection after tests."""
         self._dir.cleanup_all()
 
+    @asynctest.mock.patch('beacon_api.utils.db_load.asyncpg.connect')
+    async def test_bnd_parts(self, db_mock):
+        """Test breakend parsing parts."""
+        db_mock.return_value = Connection()
+        await self._db.connection()
+        result = self._db._bnd_parts('[CHR17:31356925[N', '126_2')
+        self.assertEqual(('chr17', 31356925, True, True, 'N', True, '126_2'), result)
+
     @asynctest.mock.patch('beacon_api.utils.db_load.asyncpg')
     async def test_connection(self, db_mock):
         """Test database URL fetching."""
@@ -255,15 +263,15 @@ class DatabaseTestCase(asynctest.TestCase):
         inf1 = INFO((1), 'S', 3)
         variant = Variant(['C'], 'T', inf1, 0.7, 'snp', 3)
         result = self._db._unpack(variant)
-        self.assertEqual(([0.3333333333333333], [1], ['SNP'], ['C'], 3), result)
+        self.assertEqual(([0.3333333333333333], [1], ['SNP'], ['C'], 3, []), result)
         inf2 = INFO(1, 'S', 3)
         variant = Variant(['AT', 'A'], 'ATA', inf2, 0.7, 'snp', 3)
         result = self._db._unpack(variant)
-        self.assertEqual(([0.3333333333333333], [1], ['DEL', 'DEL'], ['AT', 'A'], 3), result)
+        self.assertEqual(([0.3333333333333333], [1], ['DEL', 'DEL'], ['AT', 'A'], 3, []), result)
         inf3 = INFO((1), 'S', 3)
         variant = Variant(['TC'], 'T', inf3, 0.7, 'snp', 3)
         result = self._db._unpack(variant)
-        self.assertEqual(([0.3333333333333333], [1], ['INS'], ['TC'], 3), result)
+        self.assertEqual(([0.3333333333333333], [1], ['INS'], ['TC'], 3, []), result)
 
     @asynctest.mock.patch('beacon_api.utils.db_load.LOG')
     @asynctest.mock.patch('beacon_api.utils.db_load.asyncpg.connect')

--- a/tests/test_db_load.py
+++ b/tests/test_db_load.py
@@ -1,5 +1,6 @@
 import unittest
 import asynctest
+import asyncio
 from testfixtures import TempDirectory
 from beacon_api.utils.db_load import BeaconDB
 
@@ -68,6 +69,10 @@ class Statement(Transaction):
         """Initialize class."""
         pass
 
+    async def fetch(self, *args, **kwargs):
+        """Mimic fetch."""
+        return []
+
 
 class Connection:
     """Class Connection.
@@ -79,7 +84,7 @@ class Connection:
         """Initialize class."""
         pass
 
-    async def fetch(self, query):
+    async def fetch(self, *args, **kwargs):
         """Mimic fetch."""
         return [{"table_name": "DATATSET1"}, {"table_name": "DATATSET2"}]
 
@@ -99,13 +104,14 @@ class Connection:
         """Initialize class."""
         pass
 
-    async def prepare(self, query):
+    @asyncio.coroutine
+    def prepare(self, query):
         """Mimic prepare."""
-        return Statement(self, query)
+        return Statement(query)
 
     def transaction(self, *args, **kwargs):
         """Mimic execute."""
-        return Transaction(self, *args, **kwargs)
+        return Transaction(*args, **kwargs)
 
 
 class DatabaseTestCase(asynctest.TestCase):

--- a/tests/test_mate_name.py
+++ b/tests/test_mate_name.py
@@ -1,0 +1,27 @@
+import asynctest
+from beacon_api.extensions.mate_name import find_fusion
+
+
+class TestDataQueryFunctions(asynctest.TestCase):
+    """Test Data Query functions."""
+
+    def setUp(self):
+        """Set up."""
+        pass
+
+    def tearDown(self):
+        """Close database connection after tests."""
+        pass
+
+    @asynctest.mock.patch('beacon_api.extensions.mate_name.fetch_fusion_dataset')
+    async def test_find_fusion(self, mock_filtered):
+        """Test find datasets."""
+        mock_filtered.return_value = []
+        token = dict()
+        token["bona_fide_status"] = False
+        result = await find_fusion(None, 'GRCh38', None, 'Y', 'T', 'C', [], token, "NONE")
+        self.assertEqual(result, [])
+
+
+if __name__ == '__main__':
+    asynctest.main()

--- a/tests/test_mate_name.py
+++ b/tests/test_mate_name.py
@@ -1,5 +1,6 @@
 import asynctest
-from beacon_api.extensions.mate_name import find_fusion
+from beacon_api.extensions.mate_name import find_fusion, fetch_fusion_dataset
+from .test_db_load import Connection
 
 
 class TestDataQueryFunctions(asynctest.TestCase):
@@ -20,6 +21,22 @@ class TestDataQueryFunctions(asynctest.TestCase):
         token = dict()
         token["bona_fide_status"] = False
         result = await find_fusion(None, 'GRCh38', None, 'Y', 'T', 'C', [], token, "NONE")
+        self.assertEqual(result, [])
+        result_miss = await find_fusion(None, 'GRCh38', None, 'Y', 'T', 'C', [], token, "MISS")
+        self.assertEqual(result_miss, [])
+
+    async def test_fetch_fusion_dataset_call(self):
+        """Test db call for retrieving mate data."""
+        pool = asynctest.CoroutineMock()
+        pool.acquire().__aenter__.return_value = Connection()
+        assembly_id = 'GRCh38'
+        position = (10, 20, None, None, None, None)
+        chromosome = 1
+        reference = 'A'
+        result = await fetch_fusion_dataset(pool, assembly_id, position, chromosome, reference, None, None, None, False)
+        # for now it can return empty dataset
+        # in order to get a response we will have to mock it
+        # in Connection() class
         self.assertEqual(result, [])
 
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -82,6 +82,27 @@ class TestBasicFunctions(asynctest.TestCase):
             json.dumps(result)), load_schema('response')), None)
         data_find.assert_called()
 
+    @asynctest.mock.patch('beacon_api.api.query.find_fusion')
+    @asynctest.mock.patch('beacon_api.api.query.fetch_datasets_access')
+    async def test_beacon_query_bnd(self, fetch_req_datasets, data_find):
+        """Test query data response."""
+        data_find.return_value = mock_data
+        fetch_req_datasets.return_value = mock_controlled
+        pool = asynctest.CoroutineMock()
+        request = {"assemblyId": "GRCh38",
+                   "referenceName": "MT",
+                   "start": 0,
+                   "referenceBases": "C",
+                   "mateName": "1",
+                   "includeDatasetResponses": "ALL",
+                   "datasetIds": []}
+
+        params = pool, 'POST', request, {'bona_fide_status': True, 'permissions': None}, "localhost"
+        result = await query_request_handler(params)
+        self.assertEqual(jsonschema.validate(json.loads(
+            json.dumps(result)), load_schema('response')), None)
+        data_find.assert_called()
+
     @aioresponses()
     async def test_get_bona_fide(self, m):
         """Test retrieve bona_fide_status."""


### PR DESCRIPTION
### Description

This is a first attempt at dealing with mateName. ~It would be desirable in a response to get also the mate corresponding to the searched `mateName`, but as the specification is not clear on what should it contain, it is difficult to make guesses what should be in the response.~ (DONE)
yes also `"alternateBases": "N[CHR10:121482216[",` is not an alternate base.

The query in `mate_name` is quite verbose, and I am open to any suggestions to improve it.

### Related issues
Fixes #56 

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] ~This change requires a documentation update (this needs a follow up PR)~ (DONE)

### Changes Made
1. In init.sql there is a new `beacon_mate_table` that contains mate fusion specific fields
2. `beacon.extensions.mate_name` that contains a custom query for mate fusion
3. Modified JSON schema to support `BND`
4. Documentation update
5. version bump to prepare for release
6. unit tests

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

These queries should work:
* `localhost:5050/query?referenceName=1&referenceBases=N&start=108796059&assemblyId=GRCh38&variantType=BND&end=121482216&datasetIds=urn:hg:1000genome&includeDatasetResponses=HIT`
* `localhost:5050/query?referenceName=1&referenceBases=N&start=108796059&assemblyId=GRCh38&mateName=10&end=121482216&datasetIds=urn:hg:1000genome&includeDatasetResponses=HIT`
* `localhost:5050/query?referenceName=1&referenceBases=N&startMin=108796058&startMax=108796059&assemblyId=GRCh38&mateName=10&endMin=121482215&endMax=121482216&datasetIds=urn:hg:1000genome&includeDatasetResponses=HIT`

The response as of now is like:
```
{
    "beaconId": "localhost:5050",
    "apiVersion": "1.1.0",
    "exists": true,
    "alleleRequest": {
        "referenceName": "1",
        "referenceBases": "N",
        "assemblyId": "GRCh38",
        "includeDatasetResponses": "HIT",
        "datasetIds": [
            "urn:hg:1000genome"
        ],
        "startMin": 108796058,
        "startMax": 108796059,
        "endMin": 121482215,
        "endMax": 121482216
    },
    "datasetAlleleResponses": [
        {
            "datasetId": "urn:hg:1000genome",
            "referenceName": "1",
            "mateName": "10",
            "referenceID": "137_1",
            "mateID": "137_2",
            "mateStart": 121482216,
            "externalUrl": "ftp://data",
            "note": "Data.",
            "variantCount": 0,
            "callCount": 0,
            "sampleCount": 1,
            "frequency": 0,
            "exists": true,
            "referenceBases": "N",
            "alternateBases": "N[CHR10:121482216[",
            "variantType": "BND",
            "start": 108796058,
            "end": 108796059,
            "info": {
                "accessType": "PUBLIC"
            }
        },
        {
            "datasetId": "urn:hg:1000genome",
            "referenceName": "10",
            "mateName": "1",
            "referenceID": "137_2",
            "mateID": "137_1",
            "mateStart": 108796059,
            "externalUrl": "ftp://data",
            "note": "Data .",
            "variantCount": 0,
            "callCount": 0,
            "sampleCount": 1,
            "frequency": 0,
            "exists": true,
            "referenceBases": "N",
            "alternateBases": "]CHR1:108796059]N",
            "variantType": "BND",
            "start": 121482215,
            "end": 121482216,
            "info": {
                "accessType": "PUBLIC"
            }
        }
    ]
}
```

- [x] Unit Tests - ~a few tests added so far~ (90% coverage)
- [x] Needs testing (start an issue or do a follow up PR about it)

> Why the db tests do not cover the full query?

That will be the job of integration tests, as soon as we will have a proper VCF mate fusion data.

### Mentions
There will be a follow-up PR with docs and more tests.

> Did this really require a new table?

It is a design decision to separate those mate fusion from the main data table, but also open to improvement suggestions.

