### PR TITLE
Allow implicit and explicit varianttype for mate

### DIFF
--- a/beacon_api/schemas/query.json
+++ b/beacon_api/schemas/query.json
@@ -107,7 +107,12 @@
     "oneOf": [{
         "required": [
           "variantType"
-        ]
+        ],
+        "not": {
+          "required": [
+            "mateName"
+          ]
+        }
       },
       {
         "required": [
@@ -117,7 +122,24 @@
       {
         "required": [
           "mateName"
-        ]
+        ],
+        "not": {
+          "required": [
+            "variantType"
+          ]
+        }
+      },
+      {
+        "required": [
+          "mateName",
+          "variantType"
+        ],
+        "properties": {
+          "variantType": {
+            "type": "string",
+            "enum": ["BND"]
+          }
+        }
       }
     ]
   }, {

--- a/docs/optionals.rst
+++ b/docs/optionals.rst
@@ -106,6 +106,10 @@ Currently querying for a ``BND`` using ``startMin``, ``startMax`` and ``endMin``
 with ``variantType=BND`` has the response illustrated below.
 Fixed ``start`` and ``end`` can be utilised, as well as ``mateName`` as depicted above.
 
+.. note:: By default when using ``mateName``, ``variantType`` is implicit ``BND``, 
+          but it can also be set in an explicit manner using both ``mateName`` and
+          ``variantType=BND`` in a query.
+
 .. code-block:: javascript
 
     {


### PR DESCRIPTION
# Pull Request Template

### Description

<!-- Please include a summary of the change or any information deemed important. -->

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)


### Changes Made
1. JSON schema for query to set in an explicit manner using both `mateName` and `variantType=BND` in a query.
2. Docs with a note on this

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->
- [x] Needs testing - most likely integration tests

### Mentions
Discussed here: https://github.com/ga4gh-beacon/specification/issues/278
