### PR TITLE
Use enum for accessType

### DIFF
--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -73,7 +73,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND coalesce(a.end=$7, true)
                             AND coalesce(a.mateStart<=$8, true) AND coalesce(a.mateStart>=$9, true)
                             AND coalesce(a.end>=$10, true) AND coalesce(a.end<=$11, true))
-                            AND coalesce(b.accessType = any($2::varchar[]), true)
+                            AND coalesce(b.accessType = any($2::accessType[]), true)
                             {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), true);"""
                 datasets = []
                 statement = await connection.prepare(query)

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -107,7 +107,7 @@ async def fetch_dataset_metadata(db_pool, datasets=None, access_type=None):
                             updateDateTime as "updateDateTime"
                             FROM {DB_SCHEMA}dataset_metadata WHERE
                             coalesce(datasetId = any($1::varchar[]), true)
-                            AND coalesce(accessType = any($2::varchar[]), true);"""
+                            AND coalesce(accessType = any($2::accessType[]), true);"""
                 statement = await connection.prepare(query)
                 db_response = await statement.fetch(datasets_query, access_query)
                 metadata = []
@@ -175,7 +175,7 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
                             AND coalesce(a.variantType=$5, true)
                             AND coalesce(a.alternate LIKE any($6::varchar[]), true))
                             AND a.chromosome=$4
-                            AND coalesce(b.accessType = any($2::varchar[]), true)
+                            AND coalesce(b.accessType = any($2::accessType[]), true)
                             {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), true) ;"""
                 datasets = []
                 statement = await connection.prepare(query)

--- a/data/init.sql
+++ b/data/init.sql
@@ -1,3 +1,5 @@
+CREATE TYPE accessType AS enum('CONTROLLED', 'REGISTERED', 'PUBLIC');
+
 CREATE TABLE IF NOT EXISTS beacon_dataset_table (
     index SERIAL,
     name VARCHAR(128),
@@ -9,7 +11,7 @@ CREATE TABLE IF NOT EXISTS beacon_dataset_table (
     version VARCHAR(8),
     sampleCount INTEGER,
     externalUrl VARCHAR(256),
-    accessType VARCHAR(10),
+    accessType accessType,
     PRIMARY KEY (index)
 );
 


### PR DESCRIPTION
Suggestion: use a enum for the accesstype (PUBLIC, CONTROLLED, REGISTERED) instead of a string.

For compatibility with other (our) database models and because the access type can only have a fixed set of values anyway.