### PR TITLE
Avoid coalesce on fields that need index search

### DIFF
--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -167,9 +167,9 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
                             FROM {DB_SCHEMA}beacon_data_table a, {DB_SCHEMA}beacon_dataset_table b
                             WHERE a.datasetId=b.datasetId
                             AND b.assemblyId=$3
-                            AND {"NOT" if misses else ''} (coalesce(a.start=$8, true)
+                            AND {"NOT" if misses else ''} (($8::integer IS NULL OR a.start=$8)
                             AND coalesce(a.end=$9, true)
-                            AND coalesce(a.start<=$10, true) AND coalesce(a.start>=$11, true)
+                            AND ($10::integer IS NULL OR a.start<=$10) AND ($11::integer IS NULL OR a.start>=$11)
                             AND coalesce(a.end>=$12, true) AND coalesce(a.end<=$13, true)
                             AND coalesce(a.reference LIKE any($7::varchar[]), true)
                             AND coalesce(a.variantType=$5, true)


### PR DESCRIPTION
### Description
Using `coalesce` prevents the use of indices for a search. Having an index for the start position is crucial, at least for our database setup. The `IS NULL` construction on the other hand works with indices. This PR therefore changes the comparisons of `start`:
`coalesce(a.start=$8, true)` => `($8::integer IS NULL OR a.start=$8)`

This change speeds up a normal example query to our DB from 13s to 0.05s.


### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [X] Bug fix / Enhancement (non-breaking change which fixes an issue)

