### PR TITLE
Dont search all datasets when querying for a non-existing one

### DIFF
--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -52,7 +52,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND ($6 IS NULL OR a.end=$6)
                             AND ($8 IS NULL OR a.end<=$8) AND ($9 IS NULL OR a.end>=$9)
                             AND ($10 IS NULL OR a.mateStart>=$10) AND ($11 IS NULL OR a.mateStart<=$11))
-                            AND coalesce(b.accessType = any($2::accessType[]), true)
+                            AND coalesce(b.accessType = any($2::access_levels[]), true)
                             AND coalesce(a.datasetId = any($1::varchar[]), true)
                             UNION
                             SELECT {"DISTINCT ON (a.datasetId)" if misses else ''}
@@ -73,7 +73,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND ($7 IS NULL OR a.end=$7)
                             AND ($8 IS NULL OR a.mateStart<=$8) AND ($9 IS NULL OR a.mateStart>=$9)
                             AND ($10 IS NULL OR a.end>=$10) AND ($11 IS NULL OR a.end<=$11))
-                            AND coalesce(b.accessType = any($2::accessType[]), true)
+                            AND coalesce(b.accessType = any($2::access_levels[]), true)
                             AND coalesce(a.datasetId = any($1::varchar[]), false);"""
                 datasets = []
                 statement = await connection.prepare(query)

--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -49,9 +49,9 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND coalesce(a.mate=$4, true)
                             AND coalesce(a.reference LIKE any($5::varchar[]), true)
                             AND {"NOT" if misses else ''} (coalesce(a.mateStart=$7, true)
-                            AND ($6 IS NULL OR a.end=$6)
-                            AND ($8 IS NULL OR a.end<=$8) AND ($9 IS NULL OR a.end>=$9)
-                            AND ($10 IS NULL OR a.mateStart>=$10) AND ($11 IS NULL OR a.mateStart<=$11))
+                            AND ($6::integer IS NULL OR a.end=$6)
+                            AND ($8::integer IS NULL OR a.end<=$8) AND ($9::integer IS NULL OR a.end>=$9)
+                            AND ($10::integer IS NULL OR a.mateStart>=$10) AND ($11::integer IS NULL OR a.mateStart<=$11))
                             AND coalesce(b.accessType = any($2::access_levels[]), true)
                             AND coalesce(a.datasetId = any($1::varchar[]), true)
                             UNION
@@ -70,9 +70,9 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND coalesce(a.mate=$12, true)
                             AND coalesce(a.reference LIKE any($5::varchar[]), true)
                             AND {"NOT" if misses else ''} (coalesce(a.mateStart=$6, true)
-                            AND ($7 IS NULL OR a.end=$7)
-                            AND ($8 IS NULL OR a.mateStart<=$8) AND ($9 IS NULL OR a.mateStart>=$9)
-                            AND ($10 IS NULL OR a.end>=$10) AND ($11 IS NULL OR a.end<=$11))
+                            AND ($7::integer IS NULL OR a.end=$7)
+                            AND ($8::integer IS NULL OR a.mateStart<=$8) AND ($9::integer IS NULL OR a.mateStart>=$9)
+                            AND ($10::integer IS NULL OR a.end>=$10) AND ($11::integer IS NULL OR a.end<=$11))
                             AND coalesce(b.accessType = any($2::access_levels[]), true)
                             AND coalesce(a.datasetId = any($1::varchar[]), false);"""
                 datasets = []

--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -74,7 +74,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND coalesce(a.mateStart<=$8, true) AND coalesce(a.mateStart>=$9, true)
                             AND coalesce(a.end>=$10, true) AND coalesce(a.end<=$11, true))
                             AND coalesce(b.accessType = any($2::accessType[]), true)
-                            {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), true);"""
+                            {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), false);"""
                 datasets = []
                 statement = await connection.prepare(query)
                 db_response = await statement.fetch(datasets_query, access_query, assembly_id,

--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -52,7 +52,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND ($6 IS NULL OR a.end=$6)
                             AND ($8 IS NULL OR a.end<=$8) AND ($9 IS NULL OR a.end>=$9)
                             AND ($10 IS NULL OR a.mateStart>=$10) AND ($11 IS NULL OR a.mateStart<=$11))
-                            AND coalesce(b.accessType = any($2::varchar[]), true)
+                            AND coalesce(b.accessType = any($2::accessType[]), true)
                             AND coalesce(a.datasetId = any($1::varchar[]), true)
                             UNION
                             SELECT {"DISTINCT ON (a.datasetId)" if misses else ''}

--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -49,9 +49,9 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND coalesce(a.mate=$4, true)
                             AND coalesce(a.reference LIKE any($5::varchar[]), true)
                             AND {"NOT" if misses else ''} (coalesce(a.mateStart=$7, true)
-                            AND coalesce(a.end=$6, true)
-                            AND coalesce(a.end<=$8, true) AND coalesce(a.end>=$9, true)
-                            AND coalesce(a.mateStart>=$10, true) AND coalesce(a.mateStart<=$11, true))
+                            AND ($6 IS NULL OR a.end=$6)
+                            AND ($8 IS NULL OR a.end<=$8) AND ($9 IS NULL OR a.end>=$9)
+                            AND ($10 IS NULL OR a.mateStart>=$10) AND ($11 IS NULL OR a.mateStart<=$11))
                             AND coalesce(b.accessType = any($2::varchar[]), true)
                             {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), true)
                             UNION
@@ -70,9 +70,9 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                             AND coalesce(a.mate=$12, true)
                             AND coalesce(a.reference LIKE any($5::varchar[]), true)
                             AND {"NOT" if misses else ''} (coalesce(a.mateStart=$6, true)
-                            AND coalesce(a.end=$7, true)
-                            AND coalesce(a.mateStart<=$8, true) AND coalesce(a.mateStart>=$9, true)
-                            AND coalesce(a.end>=$10, true) AND coalesce(a.end<=$11, true))
+                            AND ($7 IS NULL OR a.end=$7)
+                            AND ($8 IS NULL OR a.mateStart<=$8) AND ($9 IS NULL OR a.mateStart>=$9)
+                            AND ($10 IS NULL OR a.end>=$10) AND ($11 IS NULL OR a.end<=$11))
                             AND coalesce(b.accessType = any($2::accessType[]), true)
                             {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), false);"""
                 datasets = []

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -168,9 +168,9 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
                             WHERE a.datasetId=b.datasetId
                             AND b.assemblyId=$3
                             AND {"NOT" if misses else ''} (($8::integer IS NULL OR a.start=$8)
-                            AND coalesce(a.end=$9, true)
+                            AND ($9 IS NULL OR a.end=$9)
                             AND ($10::integer IS NULL OR a.start<=$10) AND ($11::integer IS NULL OR a.start>=$11)
-                            AND coalesce(a.end>=$12, true) AND coalesce(a.end<=$13, true)
+                            AND ($12::integer IS NULL OR a.end>=$12) AND ($13::integer IS NULL OR a.end<=$13)
                             AND coalesce(a.reference LIKE any($7::varchar[]), true)
                             AND coalesce(a.variantType=$5, true)
                             AND coalesce(a.alternate LIKE any($6::varchar[]), true))

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -168,7 +168,7 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
                             WHERE a.datasetId=b.datasetId
                             AND b.assemblyId=$3
                             AND {"NOT" if misses else ''} (($8::integer IS NULL OR a.start=$8)
-                            AND ($9 IS NULL OR a.end=$9)
+                            AND ($9::integer IS NULL OR a.end=$9)
                             AND ($10::integer IS NULL OR a.start<=$10) AND ($11::integer IS NULL OR a.start>=$11)
                             AND ($12::integer IS NULL OR a.end>=$12) AND ($13::integer IS NULL OR a.end<=$13)
                             AND coalesce(a.reference LIKE any($7::varchar[]), true)

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -107,7 +107,7 @@ async def fetch_dataset_metadata(db_pool, datasets=None, access_type=None):
                             updateDateTime as "updateDateTime"
                             FROM {DB_SCHEMA}dataset_metadata WHERE
                             coalesce(datasetId = any($1::varchar[]), true)
-                            AND coalesce(accessType = any($2::accessType[]), true);"""
+                            AND coalesce(accessType = any($2::access_levels[]), true);"""
                 statement = await connection.prepare(query)
                 db_response = await statement.fetch(datasets_query, access_query)
                 metadata = []
@@ -175,7 +175,7 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
                             AND coalesce(a.variantType=$5, true)
                             AND coalesce(a.alternate LIKE any($6::varchar[]), true))
                             AND a.chromosome=$4
-                            AND coalesce(b.accessType = any($2::accessType[]), true)
+                            AND coalesce(b.accessType = any($2::access_levels[]), true)
                             AND coalesce(a.datasetId = any($1::varchar[]), false) ;"""
                 datasets = []
                 statement = await connection.prepare(query)

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -176,7 +176,7 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
                             AND coalesce(a.alternate LIKE any($6::varchar[]), true))
                             AND a.chromosome=$4
                             AND coalesce(b.accessType = any($2::accessType[]), true)
-                            {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), true) ;"""
+                            {"<>" if misses and datasets else "AND"} coalesce(a.datasetId = any($1::varchar[]), false) ;"""
                 datasets = []
                 statement = await connection.prepare(query)
                 db_response = await statement.fetch(datasets_query, access_query, assembly_id, chromosome,

--- a/data/init.sql
+++ b/data/init.sql
@@ -1,4 +1,4 @@
-CREATE TYPE accessType AS enum('CONTROLLED', 'REGISTERED', 'PUBLIC');
+CREATE TYPE access_levels AS enum('CONTROLLED', 'REGISTERED', 'PUBLIC');
 
 CREATE TABLE IF NOT EXISTS beacon_dataset_table (
     index SERIAL,
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS beacon_dataset_table (
     version VARCHAR(8),
     sampleCount INTEGER,
     externalUrl VARCHAR(256),
-    accessType accessType,
+    accessType access_levels,
     PRIMARY KEY (index)
 );
 

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -468,7 +468,7 @@ async def test_21():
     Send a query for non-existing variant targeting PUBLIC and CONTROLLED datasets with token perms, using MISS.
     Expect public and controlled data to be shown (200).
     """
-    LOG.debug(f'[21/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    LOG.debug(f'[21/{TESTS_NUMBER}] Test Non-existing/MISS variant targeting PUBLIC and CONTROLLED datasets with token perms (expect all shown)')
     payload = {"referenceName": "MT",
                "start": 8,
                "referenceBases": "T",
@@ -490,7 +490,7 @@ async def test_22():
     Send a query for non-existing variant targeting CONTROLLED datasets with token perms, using MISS.
     Expect the only the controlled, not the public data, to not be shown (200).
     """
-    LOG.debug(f'[22/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    LOG.debug(f'[22/{TESTS_NUMBER}] Test non-existing variant targeting CONTROLLED datasets with token perms, using MISS (expect only controlled shown)')
     payload = {"referenceName": "MT",
                "start": 8,
                "referenceBases": "T",
@@ -512,7 +512,7 @@ async def test_23():
     Send a query for targeting a non-existing PUBLIC datasets, using ALL.
     Expect no data to be shown (200).
     """
-    LOG.debug(f'[23/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    LOG.debug(f'[23/{TESTS_NUMBER}] Testquery for targeting a non-existing PUBLIC datasets, using ALL. (expect no data shown)')
     payload = {"referenceName": "MT",
                "start": 9,
                "referenceBases": "T",
@@ -534,7 +534,7 @@ async def test_24():
     Send a query for targeting one existing and one non-existing PUBLIC datasets, using ALL.
     Expect the existing PUBLIC data to be shown (200).
     """
-    LOG.debug(f'[24/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    LOG.debug(f'[24/{TESTS_NUMBER}] Testquery for targeting one existing and one non-existing PUBLIC datasets, using ALL. (expect only PUBLIC)')
     payload = {"referenceName": "MT",
                "start": 9,
                "referenceBases": "T",

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -527,6 +527,7 @@ async def test_23():
             assert data['exists'] is False, sys.exit('Query POST Endpoint Error!')
             assert len(data['datasetAlleleResponses']) == 0, sys.exit('Should be able to retrieve only public.')
 
+
 async def test_24():
     """Test query POST endpoint.
 
@@ -547,6 +548,7 @@ async def test_24():
             data = await resp.json()
             assert data['exists'] is True, sys.exit('Query POST Endpoint Error!')
             assert len(data['datasetAlleleResponses']) == 1, sys.exit('Should be able to retrieve only public.')
+
 
 async def main():
     """Run the tests."""

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.DEBUG)
 
 
-TESTS_NUMBER = 20
+TESTS_NUMBER = 24
 DATASET_IDS_LIST = ['urn:hg:1000genome', 'urn:hg:1000genome:registered',
                     'urn:hg:1000genome:controlled', 'urn:hg:1000genome:controlled1']
 

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -462,6 +462,92 @@ async def test_20():
             assert resp.status == 400, 'HTTP Status code error'
 
 
+async def test_21():
+    """Test query POST endpoint.
+
+    Send a query for non-existing variant targeting PUBLIC and CONTROLLED datasets with token perms, using MISS.
+    Expect public and controlled data to be shown (200).
+    """
+    LOG.debug(f'[21/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    payload = {"referenceName": "MT",
+               "start": 8,
+               "referenceBases": "T",
+               "alternateBases": "C",
+               "assemblyId": "GRCh38",
+               "datasetIds": ['urn:hg:1000genome', 'urn:hg:1000genome:controlled'],
+               "includeDatasetResponses": "MISS"}
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with aiohttp.ClientSession(headers=headers) as session:
+        async with session.post('http://localhost:5050/query', data=json.dumps(payload)) as resp:
+            data = await resp.json()
+            assert data['exists'] is False, sys.exit('Query POST Endpoint Error!')
+            assert len(data['datasetAlleleResponses']) == 2, sys.exit('Should be able to retrieve only public.')
+
+
+async def test_22():
+    """Test query POST endpoint.
+
+    Send a query for non-existing variant targeting CONTROLLED datasets with token perms, using MISS.
+    Expect the only the controlled, not the public data, to not be shown (200).
+    """
+    LOG.debug(f'[22/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    payload = {"referenceName": "MT",
+               "start": 8,
+               "referenceBases": "T",
+               "alternateBases": "C",
+               "assemblyId": "GRCh38",
+               "datasetIds": ['urn:hg:1000genome:controlled'],
+               "includeDatasetResponses": "MISS"}
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with aiohttp.ClientSession(headers=headers) as session:
+        async with session.post('http://localhost:5050/query', data=json.dumps(payload)) as resp:
+            data = await resp.json()
+            assert data['exists'] is False, sys.exit('Query POST Endpoint Error!')
+            assert len(data['datasetAlleleResponses']) == 1, sys.exit('Should be able to retrieve only public.')
+
+
+async def test_23():
+    """Test query POST endpoint.
+
+    Send a query for targeting a non-existing PUBLIC datasets, using ALL.
+    Expect no data to be shown (200).
+    """
+    LOG.debug(f'[23/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    payload = {"referenceName": "MT",
+               "start": 9,
+               "referenceBases": "T",
+               "alternateBases": "C",
+               "assemblyId": "GRCh38",
+               "datasetIds": ['urn:hg:1111genome'],
+               "includeDatasetResponses": "ALL"}
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with aiohttp.ClientSession(headers=headers) as session:
+        async with session.post('http://localhost:5050/query', data=json.dumps(payload)) as resp:
+            data = await resp.json()
+            assert data['exists'] is False, sys.exit('Query POST Endpoint Error!')
+            assert len(data['datasetAlleleResponses']) == 0, sys.exit('Should be able to retrieve only public.')
+
+async def test_24():
+    """Test query POST endpoint.
+
+    Send a query for targeting one existing and one non-existing PUBLIC datasets, using ALL.
+    Expect the existing PUBLIC data to be shown (200).
+    """
+    LOG.debug(f'[24/{TESTS_NUMBER}] Test post query (public data (success) and controlled data without token (failure))')
+    payload = {"referenceName": "MT",
+               "start": 9,
+               "referenceBases": "T",
+               "alternateBases": "C",
+               "assemblyId": "GRCh38",
+               "datasetIds": ['urn:hg:1111genome', 'urn:hg:1000genome'],
+               "includeDatasetResponses": "ALL"}
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    async with aiohttp.ClientSession(headers=headers) as session:
+        async with session.post('http://localhost:5050/query', data=json.dumps(payload)) as resp:
+            data = await resp.json()
+            assert data['exists'] is True, sys.exit('Query POST Endpoint Error!')
+            assert len(data['datasetAlleleResponses']) == 1, sys.exit('Should be able to retrieve only public.')
+
 async def main():
     """Run the tests."""
     LOG.debug('Start integration tests')
@@ -487,6 +573,10 @@ async def main():
     await test_18()
     await test_19()
     await test_20()
+    await test_21()
+    await test_22()
+    await test_23()
+    await test_24()
     LOG.debug('All integration tests have passed')
 
 


### PR DESCRIPTION
### Description
I'm not completely sure about this one, especially not considering all the discussions here https://github.com/ga4gh-beacon/specification/issues/170, but I think it makes sense.

Intended behaviour:

- no datasetId is given => all available datasets are searched (no change from before)
- invalid+valid datasetIds are given => the valid datasets are searched (no change from before)
- only invalid datasetIds are given => no datasets are searched (changed from all datasets being searched)

So if `fetch_datasets_access` returns all empty lists, it means that none of the given datasets are available, and hence the queries to the database should rather contain a negative conjunct than a positive.
