### PR TITLE
Simplify query for all and miss

### DIFF
--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -33,7 +33,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
             try:
                 if misses:
                     # For MISS and ALL. We have already found all datasets with maching variants,
-                    # so now just get one post per accesible, remaining datasets.
+                    # so now just get one post per accessible, remaining datasets.
                     query = f"""SELECT DISTINCT ON (datasetId)
                                 datasetId as "datasetId", accessType as "accessType",
                                 '{chromosome}' as "referenceName", False as "exists"

--- a/beacon_api/extensions/mate_name.py
+++ b/beacon_api/extensions/mate_name.py
@@ -37,7 +37,7 @@ async def fetch_fusion_dataset(db_pool, assembly_id, position, chromosome, refer
                     query = f"""SELECT DISTINCT ON (datasetId)
                                 datasetId as "datasetId", accessType as "accessType",
                                 '{chromosome}' as "referenceName", False as "exists"
-                                FROM {DB_SCHEMA}beacon_dataset_table 
+                                FROM {DB_SCHEMA}beacon_dataset_table
                                 WHERE coalesce(accessType = any($2::access_levels[]), true)
                                 AND assemblyId=$3
                                 AND coalesce(datasetId = any($1::varchar[]), false) ;"""

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -156,7 +156,7 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
             try:
                 if misses:
                     # For MISS and ALL. We have already found all datasets with maching variants,
-                    # so now just get one post per accesible, remaining datasets.
+                    # so now just get one post per accessible, remaining datasets.
                     query = f"""SELECT DISTINCT ON (datasetId)
                                 datasetId as "datasetId", accessType as "accessType",
                                 '{chromosome}' as "referenceName", False as "exists"

--- a/beacon_api/utils/data_query.py
+++ b/beacon_api/utils/data_query.py
@@ -160,7 +160,7 @@ async def fetch_filtered_dataset(db_pool, assembly_id, position, chromosome, ref
                     query = f"""SELECT DISTINCT ON (datasetId)
                                 datasetId as "datasetId", accessType as "accessType",
                                 '{chromosome}' as "referenceName", False as "exists"
-                                FROM {DB_SCHEMA}beacon_dataset_table 
+                                FROM {DB_SCHEMA}beacon_dataset_table
                                 WHERE coalesce(accessType = any($2::access_levels[]), true)
                                 AND assemblyId=$3
                                 AND coalesce(datasetId = any($1::varchar[]), false) ;"""

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -512,7 +512,7 @@ async def test_23():
     Send a query for targeting a non-existing PUBLIC datasets, using ALL.
     Expect no data to be shown (200).
     """
-    LOG.debug(f'[23/{TESTS_NUMBER}] Testquery for targeting a non-existing PUBLIC datasets, using ALL. (expect no data shown)')
+    LOG.debug(f'[23/{TESTS_NUMBER}] Test query for targeting a non-existing PUBLIC datasets, using ALL. (expect no data shown)')
     payload = {"referenceName": "MT",
                "start": 9,
                "referenceBases": "T",
@@ -534,7 +534,7 @@ async def test_24():
     Send a query for targeting one existing and one non-existing PUBLIC datasets, using ALL.
     Expect the existing PUBLIC data to be shown (200).
     """
-    LOG.debug(f'[24/{TESTS_NUMBER}] Testquery for targeting one existing and one non-existing PUBLIC datasets, using ALL. (expect only PUBLIC)')
+    LOG.debug(f'[24/{TESTS_NUMBER}] Test query for targeting one existing and one non-existing PUBLIC datasets, using ALL. (expect only PUBLIC)')
     payload = {"referenceName": "MT",
                "start": 9,
                "referenceBases": "T",
@@ -556,7 +556,7 @@ async def test_25():
     Send a query for non-existing variant targeting three datasets, using ALL.
     Expect no hits, but data to be shown (200).
     """
-    LOG.debug(f'[25/{TESTS_NUMBER}] Testquery for targeting three datasets, using ALL. (expect data shown)')
+    LOG.debug(f'[25/{TESTS_NUMBER}] Test query for targeting three datasets, using ALL. (expect data shown)')
     payload = {"referenceName": "MT",
                "start": 10,
                "referenceBases": "T",
@@ -578,7 +578,7 @@ async def test_26():
     Send a query for non-existing variant targeting three datasets, using MISS.
     Expect no hits, but data to be shown (200).
     """
-    LOG.debug(f'[26/{TESTS_NUMBER}] Testquery for non-existing query targeting three datasets, using MISS. (expect data shown)')
+    LOG.debug(f'[26/{TESTS_NUMBER}] Test query for non-existing query targeting three datasets, using MISS. (expect data shown)')
     payload = {"referenceName": "MT",
                "start": 10,
                "referenceBases": "T",
@@ -600,7 +600,7 @@ async def test_27():
     Send a query targeting three datasets, using MISS.
     Expect hits, but no data to be shown (200).
     """
-    LOG.debug(f'[26/{TESTS_NUMBER}] Testquery for targeting three datasets, using MISS. (expect no data shown)')
+    LOG.debug(f'[27/{TESTS_NUMBER}] Test query for targeting three datasets, using MISS. (expect no data shown)')
     payload = {"referenceName": "MT",
                "start": 9,
                "referenceBases": "T",


### PR DESCRIPTION
# Pull Request Template

### Description

Simplify the extra query asked for `MISS` and `ALL`, in order to speed things up.

When doing the extra query (with `missed=True`), we already now which datasets that include hits, so we don't need to redo the whole query (the negated query can be quite time consuming). We only need to get the `datasetId` and `accessType` for each the remaining datasets.

This breaks the more compact sql queries from before, and might make things less pretty. But will also be faster (if you know of other ways to make the negated queries faster, like adding other types of indices or so, please let me know).

The `chromosome` is kept in the answer for `MISS` and `ALL`, in order to get the same behavior as before.

### Type of change

- [X] Non-breaking change which fixes an issue

### Changes Made

- Changed the sql queries in `data_query.py`, and correspondingly in `mate_name.py`.
- Added integration tests (maybe too many?)


### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [X] Integration Tests

