### PR TITLE
Make sample queries more easily configurable

### DIFF
--- a/beacon_api/__init__.py
+++ b/beacon_api/__init__.py
@@ -5,7 +5,7 @@
 """
 import datetime
 
-from .conf import CONFIG_INFO
+from .conf import CONFIG_INFO, SAMPLE_QUERIES
 
 __title__ = CONFIG_INFO.title
 __version__ = CONFIG_INFO.version
@@ -34,3 +34,5 @@ __org_welcomeUrl__ = CONFIG_INFO.org_welcomeUrl
 __org_contactUrl__ = CONFIG_INFO.org_contactUrl
 __org_logoUrl__ = CONFIG_INFO.org_logoUrl
 __org_info__ = {'orgInfo': CONFIG_INFO.org_info}
+
+__sample_queries__ = SAMPLE_QUERIES

--- a/beacon_api/api/info.py
+++ b/beacon_api/api/info.py
@@ -9,7 +9,7 @@ and their associated metadata.
 from .. import __apiVersion__, __title__, __version__, __description__, __url__, __alturl__, __handover_beacon__
 from .. import __createtime__, __updatetime__, __org_id__, __org_name__, __org_description__
 from .. import __org_address__, __org_logoUrl__, __org_welcomeUrl__, __org_info__, __org_contactUrl__
-from .. import  __sample_queries__,__handover_drs__
+from .. import  __sample_queries__, __handover_drs__
 from ..utils.data_query import fetch_dataset_metadata
 from ..extensions.handover import make_handover
 from aiocache import cached

--- a/beacon_api/api/info.py
+++ b/beacon_api/api/info.py
@@ -9,7 +9,7 @@ and their associated metadata.
 from .. import __apiVersion__, __title__, __version__, __description__, __url__, __alturl__, __handover_beacon__
 from .. import __createtime__, __updatetime__, __org_id__, __org_name__, __org_description__
 from .. import __org_address__, __org_logoUrl__, __org_welcomeUrl__, __org_info__, __org_contactUrl__
-from .. import  __sample_queries__, __handover_drs__
+from .. import __sample_queries__, __handover_drs__
 from ..utils.data_query import fetch_dataset_metadata
 from ..extensions.handover import make_handover
 from aiocache import cached

--- a/beacon_api/api/info.py
+++ b/beacon_api/api/info.py
@@ -9,7 +9,7 @@ and their associated metadata.
 from .. import __apiVersion__, __title__, __version__, __description__, __url__, __alturl__, __handover_beacon__
 from .. import __createtime__, __updatetime__, __org_id__, __org_name__, __org_description__
 from .. import __org_address__, __org_logoUrl__, __org_welcomeUrl__, __org_info__, __org_contactUrl__
-from .. import __handover_drs__
+from .. import  __sample_queries__,__handover_drs__
 from ..utils.data_query import fetch_dataset_metadata
 from ..extensions.handover import make_handover
 from aiocache import cached
@@ -25,6 +25,7 @@ async def beacon_info(host, pool):
     beacon_dataset = await fetch_dataset_metadata(pool)
 
     # If one sets up a beacon it is recommended to adjust these sample requests
+    # for instance by adding a list of other samples in beacon_api/conf/sample_queries.json
     sample_allele_request = [{
         "alternateBases": "G",
         "referenceBases": "A",
@@ -75,7 +76,7 @@ async def beacon_info(host, pool):
         'createDateTime': __createtime__,
         'updateDateTime': __updatetime__,
         'datasets': beacon_dataset,
-        'sampleAlleleRequests': sample_allele_request,
+        'sampleAlleleRequests': __sample_queries__ or sample_allele_request,
         'info': {"achievement": "World's first 1.0 Beacon"},
     }
 

--- a/beacon_api/conf/__init__.py
+++ b/beacon_api/conf/__init__.py
@@ -1,5 +1,6 @@
 """Beacon Python Application Configuration."""
 
+import json
 import os
 from configparser import ConfigParser
 from collections import namedtuple
@@ -58,3 +59,6 @@ def parse_oauth2_config_file(path):
 
 
 OAUTH2_CONFIG = parse_oauth2_config_file(os.environ.get('CONFIG_FILE', os.path.join(os.path.dirname(__file__), 'config.ini')))
+
+sampleq_file = os.environ.get('SAMPLEQUERY_FILE', os.path.join(os.path.dirname(__file__), 'sample_queries.json'))
+SAMPLE_QUERIES = json.load(open(sampleq_file)) if os.path.isfile(sampleq_file) else []

--- a/beacon_api/conf/__init__.py
+++ b/beacon_api/conf/__init__.py
@@ -59,6 +59,6 @@ def parse_oauth2_config_file(path):
 
 
 OAUTH2_CONFIG = parse_oauth2_config_file(os.environ.get('CONFIG_FILE', os.path.join(os.path.dirname(__file__), 'config.ini')))
-
+# Sample query file should be of format [{BeaconAlleleRequest}] https://github.com/ga4gh-beacon/specification/
 sampleq_file = os.environ.get('SAMPLEQUERY_FILE', os.path.join(os.path.dirname(__file__), 'sample_queries.json'))
 SAMPLE_QUERIES = json.load(open(sampleq_file)) if os.path.isfile(sampleq_file) else []


### PR DESCRIPTION
### Description

Allow a `sample_queries.json` file in `beacon_api/conf` with sample queries to show in the `info` call, instead of the ones in `beacon_api/api/info.py`.

Makes it easier to have your own sample queries, since you will not need to edit the `beacon_api/api/info.py` to change this.

### Type of change

- [X]  New feature (non-breaking change which adds functionality)

### Changes Made

Add another optional config-file, the content of this will be stored in `__sample_queries__`.