### PR TITLE
Aligning Beacon with GA4GH standards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# Pull Request Template
-
 ### Description
 
 <!-- Please include a summary of the change or any information deemed important. -->

--- a/beacon_api/__init__.py
+++ b/beacon_api/__init__.py
@@ -12,6 +12,7 @@ __version__ = CONFIG_INFO.version
 __author__ = CONFIG_INFO.author
 __license__ = CONFIG_INFO.license
 __copyright__ = CONFIG_INFO.copyright
+__docs_url__ = CONFIG_INFO.docs_url
 __handover_drs__ = CONFIG_INFO.handover_drs
 __handover_datasets__ = CONFIG_INFO.handover_datasets
 __handover_beacon__ = CONFIG_INFO.handover_beacon

--- a/beacon_api/api/info.py
+++ b/beacon_api/api/info.py
@@ -9,11 +9,29 @@ and their associated metadata.
 from .. import __apiVersion__, __title__, __version__, __description__, __url__, __alturl__, __handover_beacon__
 from .. import __createtime__, __updatetime__, __org_id__, __org_name__, __org_description__
 from .. import __org_address__, __org_logoUrl__, __org_welcomeUrl__, __org_info__, __org_contactUrl__
-from .. import __sample_queries__, __handover_drs__
+from .. import __sample_queries__, __handover_drs__, __docs_url__
 from ..utils.data_query import fetch_dataset_metadata
 from ..extensions.handover import make_handover
 from aiocache import cached
 from aiocache.serializers import JsonSerializer
+
+
+@cached(ttl=60, key="ga4gh_info", serializer=JsonSerializer())
+async def ga4gh_info(host):
+    """Construct the `Beacon` app information dict in GA4GH Discovery format.
+
+    :return beacon_info: A dict that contain information about the ``Beacon`` endpoint.
+    """
+    beacon_info = {
+        # TO DO implement some fallback mechanism for ID
+        'id': '.'.join(reversed(host.split('.'))),
+        'name': __title__,
+        'description': __description__,
+        'documentationUrl': __docs_url__,
+        'contactUrl': __org_contactUrl__,
+        'version': __version__
+    }
+    return beacon_info
 
 
 @cached(ttl=60, key="info_key", serializer=JsonSerializer())

--- a/beacon_api/app.py
+++ b/beacon_api/app.py
@@ -8,7 +8,7 @@ import os
 import sys
 import aiohttp_cors
 
-from .api.info import beacon_info
+from .api.info import beacon_info, ga4gh_info
 from .api.query import query_request_handler
 from .conf.config import init_db_pool
 from .schemas import load_schema
@@ -25,7 +25,8 @@ asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 # ----------------------------------------------------------------------------------------------------------------------
 #                                         INFO END POINT OPERATIONS
 # ----------------------------------------------------------------------------------------------------------------------
-@routes.get('/', name='info')
+@routes.get('/')  # For Beacon API Specification
+@routes.get('/service-info')  # For GA4GH Discovery Specification
 async def beacon_get(request):
     """
     Use the HTTP protocol 'GET' to return a Json object of all the necessary info on the beacon and the API.
@@ -35,9 +36,14 @@ async def beacon_get(request):
     :type beacon: Dict
     :return beacon: The method returns an example Beacon characteristic to beacon info endpoint.
     """
-    LOG.info('GET request to the info endpoint "/".')
-    db_pool = request.app['pool']
-    response = await beacon_info(request.host, db_pool)
+    LOG.info('GET request to the info endpoint.')
+    if str(request.rel_url) == '/service-info':
+        LOG.info('Using GA4GH Discovery format for Service Info.')
+        response = await ga4gh_info(request.host)
+    else:
+        LOG.info('Using Beacon API Specification format for Service Info.')
+        db_pool = request.app['pool']
+        response = await beacon_info(request.host, db_pool)
     return web.json_response(response)
 
 

--- a/beacon_api/conf/__init__.py
+++ b/beacon_api/conf/__init__.py
@@ -21,7 +21,7 @@ def parse_config_file(path):
         'author': config.get('beacon_general_info', 'author'),
         'license': config.get('beacon_general_info', 'license'),
         'copyright': config.get('beacon_general_info', 'copyright'),
-        'docs_url': config.get('beacon_general_info', 'docsUrl'),
+        'docs_url': config.get('beacon_general_info', 'docs_url'),
         'handover_drs': config.get('handover_info', 'drs', fallback=''),
         'handover_datasets': parse_drspaths(config.get('handover_info', 'dataset_paths', fallback='')),
         'handover_beacon': parse_drspaths(config.get('handover_info', 'beacon_paths', fallback='')),

--- a/beacon_api/conf/__init__.py
+++ b/beacon_api/conf/__init__.py
@@ -21,6 +21,7 @@ def parse_config_file(path):
         'author': config.get('beacon_general_info', 'author'),
         'license': config.get('beacon_general_info', 'license'),
         'copyright': config.get('beacon_general_info', 'copyright'),
+        'docs_url': config.get('beacon_general_info', 'docsUrl'),
         'handover_drs': config.get('handover_info', 'drs', fallback=''),
         'handover_datasets': parse_drspaths(config.get('handover_info', 'dataset_paths', fallback='')),
         'handover_beacon': parse_drspaths(config.get('handover_info', 'beacon_paths', fallback='')),

--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -18,6 +18,9 @@ license=Apache 2.0
 # Copyright holder for this software
 copyright=CSC - IT Center for Science
 
+# Documentation url for GA4GH Discovery
+docsUrl=https://beacon-python.readthedocs.io/en/latest/
+
 
 [beacon_api_info]
 # Version of the Beacon API specification this implementation adheres to

--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -19,7 +19,7 @@ license=Apache 2.0
 copyright=CSC - IT Center for Science
 
 # Documentation url for GA4GH Discovery
-docsUrl=https://beacon-python.readthedocs.io/en/latest/
+docs_url=https://beacon-python.readthedocs.io/en/latest/
 
 
 [beacon_api_info]

--- a/deploy/test/auth_test.ini
+++ b/deploy/test/auth_test.ini
@@ -18,6 +18,8 @@ license=Apache 2.0
 # Copyright holder for this software
 copyright=CSC - IT Center for Science
 
+# Documentation url for GA4GH Discovery
+docs_url=https://beacon-python.readthedocs.io/en/latest/
 
 [beacon_api_info]
 # Version of the Beacon API specification this implementation adheres to

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -698,3 +698,18 @@ async def test_31():
             data = await resp.json()
             assert data['exists'] is True, sys.exit('Query POST Endpoint Error!')
             assert resp.status == 200, 'HTTP Status code error'
+
+
+async def test_32():
+    """Test the GA4GH Discovery info endpoint.
+
+    Discovery endpoint should be smaller than Beacon info endpoint.
+    """
+    LOG.debug('Test GA4GH Discovery info endpoint')
+    async with aiohttp.ClientSession() as session:
+        async with session.get('http://localhost:5050/service-info') as resp:
+            data = await resp.json()
+            # GA4GH Discovery Service-Info is small and its length should be between 3 and 6, when the Beacon info is very long
+            # https://github.com/ga4gh-discovery/service-info/blob/develop/service-info.yaml
+            assert 3 <= len(data) <= 6, 'Service info size error'
+            assert resp.status == 200, 'HTTP Status code error'

--- a/docs/instructions.rst
+++ b/docs/instructions.rst
@@ -67,7 +67,7 @@ pointing to the location of the file using `CONFIG_FILE` environment variable.
 
 .. literalinclude:: /../beacon_api/conf/config.ini
    :language: python
-   :lines: 1-65
+   :lines: 1-68
 
 .. _oauth2:
 

--- a/docs/permissions.rst
+++ b/docs/permissions.rst
@@ -20,7 +20,7 @@ message that contains a ``bona_fide_status`` key. Custom servers can be set up t
 
 .. literalinclude:: /../beacon_api/utils/validate.py
    :language: python
-   :lines: 101-111
+   :lines: 102-112
 
 .. note:: The ``bona_fide_status`` key is provided base on ELIXIR AAI bona fide status of a researcher.
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,6 +77,16 @@ class AppTestCase(AioHTTPTestCase):
         assert 200 == resp.status
 
     @unittest_run_loop
+    async def test_ga4gh_info(self):
+        """Test the GA4GH Discovery info endpoint.
+
+        The status should always be 200.
+        """
+        with asynctest.mock.patch('beacon_api.app.beacon_info', side_effect={"smth": "value"}):
+            resp = await self.client.request("GET", "/service-info")
+        assert 200 == resp.status
+
+    @unittest_run_loop
     async def test_post_info(self):
         """Test the info endpoint with POST.
 


### PR DESCRIPTION
# GA4GH Discovery Service Info

### Description
[GA4GH product approval workflow](https://www.ga4gh.org/how-we-work/ga4gh-product-approval/) describes, that services **should use** the standardised `/service-info` endpoint with the [GA4GH Discovery service-info](https://github.com/ga4gh-discovery/service-info). The Beacon API specification doesn't fulfill these requirements, and this PR implements a simple solution of expressing both info-endpoints at the same time.

### Related issues
Fixes #98 

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Changes Made
* Added `/service-info` endpoint alongside the previous `/` endpoint;
* Added new field to `config.ini` that points to a new key in the GA4GH Discovery service-info: `docsUrl=https://beacon-python.readthedocs.io/en/latest/`;
* Added unit test for new endpoint;
* Added integration test for new endpoint;
* Updated docs due to line number shifting in `config.ini` from the new key.

### Testing
- [x] Unit Tests
- [x] Integration Tests

### Mentions
This is a very low priority update, but hey! Fourth PR of the day!