### PR TITLE
Fix shifted line numbers

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -28,11 +28,11 @@ Example snippets from ``query.json``:
 
 .. literalinclude:: /../beacon_api/schemas/query.json
   :language: javascript
-  :lines: 41-56
+  :lines: 23-46
 
 .. literalinclude:: /../beacon_api/schemas/query.json
    :language: javascript
-   :lines: 72-97
+   :lines: 78-108
 
 
 **********

--- a/docs/instructions.rst
+++ b/docs/instructions.rst
@@ -79,7 +79,7 @@ The configuration variables reside in the same `CONFIG_FILE` as described above 
 
 .. literalinclude:: /../beacon_api/conf/config.ini
    :language: python
-   :lines: 87-95
+   :lines: 90-98
 
 ``server`` should point to an API that returns a public key which can be used to validate the received Bearer token.
 ``issuers`` is a string of comma separated values, e.g. `one,two,three` without spaces. The issuers string contains

--- a/docs/optionals.rst
+++ b/docs/optionals.rst
@@ -17,7 +17,7 @@ The handover protocol can be configured in ``config.ini`` as follows:
 
 .. literalinclude:: /../beacon_api/conf/config.ini
    :language: python
-   :lines: 68-84
+   :lines: 71-87
 
 .. note:: Handover protocol is disabled by default, as shown by the commented out ``drs`` variable. This variable should point
           to the server, which serves the additional data. To enable the handover protocol, uncomment the ``drs`` variable.


### PR DESCRIPTION
### Fix shifted line numbers
Some line numbers were pointing to wrong places in files due to changes in those files. Adjusted line numbers in docs to take shifting into account.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
* Adjusted line numbers in file inclusions.

### Testing
- [x] Tests do not apply
