### PR TITLE
Hotfix for breaking changes in ELIXIR AAI

### DIFF
--- a/beacon_api/conf/__init__.py
+++ b/beacon_api/conf/__init__.py
@@ -4,6 +4,7 @@ import json
 import os
 from configparser import ConfigParser
 from collections import namedtuple
+from distutils.util import strtobool
 
 
 def parse_drspaths(paths):
@@ -55,7 +56,8 @@ def parse_oauth2_config_file(path):
         'server': config.get('oauth2', 'server'),
         'issuers': config.get('oauth2', 'issuers'),
         'bona_fide': config.get('oauth2', 'bona_fide'),
-        'audience': config.get('oauth2', 'audience') or None
+        'audience': config.get('oauth2', 'audience') or None,
+        'verify_aud': strtobool(config.get('oauth2', 'verify_aud'))
     }
     return namedtuple("Config", config_vars.keys())(*config_vars.values())
 

--- a/beacon_api/conf/__init__.py
+++ b/beacon_api/conf/__init__.py
@@ -54,7 +54,8 @@ def parse_oauth2_config_file(path):
     config_vars = {
         'server': config.get('oauth2', 'server'),
         'issuers': config.get('oauth2', 'issuers'),
-        'bona_fide': config.get('oauth2', 'bona_fide')
+        'bona_fide': config.get('oauth2', 'bona_fide'),
+        'audience': config.get('oauth2', 'audience') or None
     }
     return namedtuple("Config", config_vars.keys())(*config_vars.values())
 

--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -102,3 +102,8 @@ bona_fide=https://login.elixir-czech.org/oidc/userinfo
 # the network administrator should supply you with their `aud` identifier
 # in other cases, leave this empty or use the personal identifier given to you from your AAI
 audience=
+
+# Verify `aud` claim of token.
+# If your service is not part of any network or AAI, but you still want to use tokens
+# produced by other AAI parties, set this value to False to skip the audience validation step
+verify_aud=True

--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -96,3 +96,9 @@ issuers=https://login.elixir-czech.org/oidc/
 
 # Where to check the bona_fide_status
 bona_fide=https://login.elixir-czech.org/oidc/userinfo
+
+# String or URI to state the intended recipient of the token.
+# If your application is part of a larger network,
+# the network administrator should supply you with their `aud` identifier
+# in other cases, leave this empty or use the personal identifier given to you from your AAI
+audience=

--- a/beacon_api/utils/validate.py
+++ b/beacon_api/utils/validate.py
@@ -161,8 +161,9 @@ def token_auth():
             key = await get_key()
             issuers = OAUTH2_CONFIG.issuers.split(',')
             aud = os.environ.get('JWT_AUD', OAUTH2_CONFIG.audience)  # defaults to `None` if neither is given
+            verify_aud = OAUTH2_CONFIG.verify_aud  # Option to skip verification of `aud` claim
             try:
-                decodedData = jwt.decode(token, key, issuer=issuers, audience=aud)
+                decodedData = jwt.decode(token, key, issuer=issuers, audience=aud, options={'verify_aud': verify_aud})
                 LOG.info('Auth Token Decoded.')
                 LOG.info(f'Identified as {decodedData["sub"]} user by {decodedData["iss"]}.')
                 # for now the permissions just reflects that the data can be decoded from token

--- a/beacon_api/utils/validate.py
+++ b/beacon_api/utils/validate.py
@@ -160,8 +160,9 @@ def token_auth():
 
             key = await get_key()
             issuers = OAUTH2_CONFIG.issuers.split(',')
+            aud = os.environ.get('JWT_AUD', OAUTH2_CONFIG.audience)  # defaults to `None` if neither is given
             try:
-                decodedData = jwt.decode(token, key, issuer=issuers)
+                decodedData = jwt.decode(token, key, issuer=issuers, audience=aud)
                 LOG.info('Auth Token Decoded.')
                 LOG.info(f'Identified as {decodedData["sub"]} user by {decodedData["iss"]}.')
                 # for now the permissions just reflects that the data can be decoded from token

--- a/deploy/test/auth_test.ini
+++ b/deploy/test/auth_test.ini
@@ -93,3 +93,14 @@ issuers=http://somebody.com
 
 # Where to check the bona_fide_status
 bona_fide=http://mockauth:8000/userinfo
+
+# String or URI to state the intended recipient of the token.
+# If your application is part of a larger network,
+# the network administrator should supply you with their `aud` identifier
+# in other cases, leave this empty or use the personal identifier given to you from your AAI
+audience=
+
+# Verify `aud` claim of token.
+# If your service is not part of any network or AAI, but you still want to use tokens
+# produced by other AAI parties, set this value to False to skip the audience validation step
+verify_aud=False


### PR DESCRIPTION
### Hotfix for changed JWT format
ELIXIR AAI pushed an unannounced breaking change into production with the addition of the `aud` claim in JWT. The recipient (Beacon) must know this claim beforehand in order to decode the token. This PR adds two fixes to this issue, by giving the ability to validate the `aud` claim, or to skip the validation.

#### Okay, how do I deal with this?
1. If you have connected your Beacon to an AAI, ask your AAI provider for the `aud` identifier. See **Option A** below.
2. If you have connected your Beacon to a Beacon Network, as your Beacon Network administrator for the `aud` identifier. **See Option A** below.
3. If neither of the two options above fit your case, it means you are not part of the intended audience of the token, and you should skip the validation of the `aud` claim. **See Option B** below.


#### Options _(how to solve this issue)_
In `config.ini` there are two new keys in the `oauth2` section: `audience` and `verify_aud`. If your Beacon receives a token that has an `aud` claim you have two choices:
* **Option A:** Add that string or URI to `audience` key in `config.ini` or `JWT_AUD` environment variable beforehand;
or
* **Option B:** Skip the validation of the `aud` claim, by setting `verify_aud=False` in `config.ini`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (this needs a follow up PR)

### Changes Made
* Added new `audience` key to config;
* Added new `verify_aud` key to config;
* Added new parameters to JWT decoding in `validate.py`.

### Testing
- [ ] Integration Tests
- [x] Needs testing (start an issue or do a follow up PR about it)

### To do at a later date
* Integration tests for:
  * `aud` claim is present and app knows it;
  * `aud` claim is present, but app doesn't know it;
  * `aud` claim is present, but app skips its validation.
* Documentation for `aud` claim.