### PR TITLE
Set verify_aud to False by default

### DIFF
--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -104,6 +104,8 @@ bona_fide=https://login.elixir-czech.org/oidc/userinfo
 audience=
 
 # Verify `aud` claim of token.
+# If you want to validate the intended audience of a token, set this value to True.
+# This option requires you to also set a value for the `audience` key above.
 # If your service is not part of any network or AAI, but you still want to use tokens
 # produced by other AAI parties, set this value to False to skip the audience validation step
-verify_aud=True
+verify_aud=False


### PR DESCRIPTION
Set `verify_aud=False` to be the default value, until a better solution comes up for handling multiple audiences. #110 