### PR TITLE
Update GA4GH service-info

### DIFF
--- a/beacon_api/api/info.py
+++ b/beacon_api/api/info.py
@@ -26,10 +26,13 @@ async def ga4gh_info(host):
         # TO DO implement some fallback mechanism for ID
         'id': '.'.join(reversed(host.split('.'))),
         'name': __title__,
+        "type": "urn:ga4gh:beacon",
         'description': __description__,
         'documentationUrl': __docs_url__,
+        "organization": __org_id__,
         'contactUrl': __org_contactUrl__,
-        'version': __version__
+        'version': __version__,
+        "extension": {}
     }
     return beacon_info
 

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -711,5 +711,6 @@ async def test_32():
             data = await resp.json()
             # GA4GH Discovery Service-Info is small and its length should be between 3 and 6, when the Beacon info is very long
             # https://github.com/ga4gh-discovery/service-info/blob/develop/service-info.yaml
-            assert 3 <= len(data) <= 6, 'Service info size error'
+            assert 5 <= len(data) <= 9, 'Service info size error'  # ga4gh service-info has 5 required keys and at most 9 with optionals
+            assert data['type'] == 'urn:ga4gh:beacon', 'Service type error'  # a new key used in beacon network
             assert resp.status == 200, 'HTTP Status code error'


### PR DESCRIPTION
### Update GA4GH service-info
Updated GA4GH service-info to latest format.

### Related issues
Fixes #119 

### Type of change
- Format update

### Changes Made
- Updated response format in `info.py`;
- Update integration test for `/service-info`.

### Testing
- [x] Integration Tests
