### PR TITLE
Refactor with some misses for tests and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ LABEL maintainer "CSC Developers"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.vcs-url="https://github.com/CSCFI/beacon-python"
 
+RUN apk add --update \
+    && apk add --no-cache curl bzip2 xz
+
 COPY --from=BUILD usr/local/lib/python3.7/ usr/local/lib/python3.7/
 
 COPY --from=BUILD /usr/local/bin/gunicorn /usr/local/bin/

--- a/tests/test.ini
+++ b/tests/test.ini
@@ -86,13 +86,13 @@ org_info=CSC represents Finland in the ELIXIR partner nodes
 
 [oauth2]
 # OAuth2 server that returns public key for JWT Bearer token validation
-server=http://mockauth:8000/jwk
+server=http://test.csc.fi/jwk
 
 # Authenticated Bearer token issuers, separated by commas if multiple
 issuers=http://test.csc.fi
 
 # Where to check the bona_fide_status
-userinfo=http://mockauth:8000/userinfo
+userinfo=http://test.csc.fi/userinfo
 
 # What the value of `AcceptedTermsAndPolicies` and `ResearcherStatus` must be in order
 # to be recognised as a Bona Fide researcher
@@ -102,9 +102,9 @@ bona_fide_value=https://doi.org/10.1038/s41431-018-0219-y
 # If your application is part of a larger network,
 # the network administrator should supply you with their `aud` identifier
 # in other cases, leave this empty or use the personal identifier given to you from your AAI
-audience=aud1,aud2
+audience=
 
 # Verify `aud` claim of token.
 # If your service is not part of any network or AAI, but you still want to use tokens
 # produced by other AAI parties, set this value to False to skip the audience validation step
-verify_aud=True
+verify_aud=False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,7 +29,7 @@ def generate_token(issuer):
         "k": "hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG-Onbc6mxCcYg"
     }
     header = {
-        "jku": "https://login.elixir-czech.org/oidc/jwk",
+        "jku": "http://test.csc.fi/jwk",
         "kid": "018c0ae5-4d9b-471b-bfd6-eef314bc7037",
         "alg": "HS256"
     }
@@ -53,7 +53,7 @@ def generate_bad_token():
         "k": "hJtXIZ2uSN5kbQfbtTNWbpdmhkV8FJG-Onbc6mxCcYg"
     }
     header = {
-        "jku": "https://login.elixir-czech.org/oidc/jwk",
+        "jku": "http://test.csc.fi/jwk",
         "kid": "018c0ae5-4d9b-471b-bfd6-eef314bc7037",
         "alg": "HS256"
     }
@@ -87,7 +87,7 @@ class AppTestCase(AioHTTPTestCase):
     @asynctest.mock.patch('beacon_api.app.initialize', side_effect=create_db_mock)
     async def get_application(self, pool_mock):
         """Retrieve web Application for test."""
-        token, public_key = generate_token('https://login.elixir-czech.org/oidc/')
+        token, public_key = generate_token('http://test.csc.fi')
         self.bad_token, _ = generate_bad_token()
         self.env = EnvironmentVarGuard()
         self.env.set('PUBLIC_KEY', json.dumps(public_key))

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -113,14 +113,14 @@ class TestBasicFunctions(asynctest.TestCase):
     @aioresponses()
     async def test_bad_none_retrieve_user_data(self, m):
         """Test a failing userdata call because response didn't have ga4gh format."""
-        m.get("https://login.elixir-czech.org/oidc/userinfo", payload={"not_ga4gh": [{}]})
+        m.get("http://test.csc.fi/userinfo", payload={"not_ga4gh": [{}]})
         user_data = await retrieve_user_data('good_token')
         self.assertEqual(user_data, None)
 
     @aioresponses()
     async def test_good_retrieve_user_data(self, m):
         """Test a passing call to retrieve user data."""
-        m.get("https://login.elixir-czech.org/oidc/userinfo", payload={"ga4gh": [{}]})
+        m.get("http://test.csc.fi/userinfo", payload={"ga4gh": [{}]})
         user_data = await retrieve_user_data('good_token')
         self.assertEqual(user_data, [{}])
 
@@ -140,7 +140,7 @@ f9BjIARRfVrbxVxiZHjU6zL6jY5QJdh1QCmENoejj_ytspMmGW7yMRxzUqgxcAqOBpVm0b-_mW3HoBdj
                     "e": "AQAB"
                 }
             ]}
-        m.get("https://login.elixir-czech.org/oidc/jwk", payload=data)
+        m.get("http://test.csc.fi/jwk", payload=data)
         result = await get_key()
         # key = load_pem_public_key(result.encode('utf-8'), backend=default_backend())
         self.assertTrue(isinstance(result, dict))

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,8 @@ deps =
 commands = flake8 .
 
 [testenv]
+setenv =
+    CONFIG_FILE = {toxinidir}/tests/test.ini
 passenv = TRAVIS TRAVIS_*
 deps =
     .[test]


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
Tests should include URLs that are controllable, even if those URLs are mocked using by `aioresponses` we should still not use URLs used in deployment. We would like to be able to always predict behaviour in tests and avoid unpredictable behaviour.

It is a good idea to have something else in the tests than default configuration.

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made

1. set environment variable for custom tests config file in `tox`
2. missed some packages in Dockerfile
3. modified tests URL to use something else than default config.

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] Unit Tests

### Mentions
<!-- Shout outs to your friends that you made this happen or need help. -->
Default configuration should not point to elixir as this is general purpose.