### PR TITLE
Update for GA4GH Service-info

### DIFF
--- a/beacon_api/__init__.py
+++ b/beacon_api/__init__.py
@@ -26,7 +26,6 @@ __alturl__ = CONFIG_INFO.alturl
 __createtime__ = CONFIG_INFO.createtime
 __updatetime__ = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')  # Every restart of the application means an update to it
 
-
 __org_id__ = CONFIG_INFO.org_id
 __org_name__ = CONFIG_INFO.org_name
 __org_description__ = CONFIG_INFO.org_description
@@ -37,3 +36,7 @@ __org_logoUrl__ = CONFIG_INFO.org_logoUrl
 __org_info__ = {'orgInfo': CONFIG_INFO.org_info}
 
 __sample_queries__ = SAMPLE_QUERIES
+
+# GA4GH Discovery
+__service_type__ = f'{CONFIG_INFO.service_type}:{__apiVersion__}'
+__service_env__ = CONFIG_INFO.environment

--- a/beacon_api/api/info.py
+++ b/beacon_api/api/info.py
@@ -9,7 +9,7 @@ and their associated metadata.
 from .. import __apiVersion__, __title__, __version__, __description__, __url__, __alturl__, __handover_beacon__
 from .. import __createtime__, __updatetime__, __org_id__, __org_name__, __org_description__
 from .. import __org_address__, __org_logoUrl__, __org_welcomeUrl__, __org_info__, __org_contactUrl__
-from .. import __sample_queries__, __handover_drs__, __docs_url__
+from .. import __sample_queries__, __handover_drs__, __docs_url__, __service_type__, __service_env__
 from ..utils.data_query import fetch_dataset_metadata
 from ..extensions.handover import make_handover
 from aiocache import cached
@@ -26,13 +26,18 @@ async def ga4gh_info(host):
         # TO DO implement some fallback mechanism for ID
         'id': '.'.join(reversed(host.split('.'))),
         'name': __title__,
-        "type": "urn:ga4gh:beacon",
+        "type": __service_type__,
         'description': __description__,
-        'documentationUrl': __docs_url__,
-        "organization": __org_id__,
+        "organization": {
+            "name": __org_name__,
+            "url": __org_welcomeUrl__,
+        },
         'contactUrl': __org_contactUrl__,
-        'version': __version__,
-        "extension": {}
+        'documentationUrl': __docs_url__,
+        'createdAt': __createtime__,
+        'updatedAt': __updatetime__,
+        'environment': __service_env__,
+        'version': __version__
     }
     return beacon_info
 

--- a/beacon_api/conf/__init__.py
+++ b/beacon_api/conf/__init__.py
@@ -33,6 +33,8 @@ def parse_config_file(path):
         'url': config.get('beacon_api_info', 'url'),
         'alturl': config.get('beacon_api_info', 'alturl'),
         'createtime': config.get('beacon_api_info', 'createtime'),
+        'service_type': config.get('beacon_api_info', 'service_type'),
+        'environment': config.get('beacon_api_info', 'environment'),
         'org_id': config.get('organisation_info', 'org_id'),
         'org_name': config.get('organisation_info', 'org_name'),
         'org_description': config.get('organisation_info', 'org_description'),

--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -7,7 +7,7 @@
 title=GA4GHBeacon at CSC
 
 # Version of the Beacon implementation
-version=1.4.0
+version=1.4.1
 
 # Author of this software
 author=CSC developers
@@ -40,6 +40,13 @@ alturl=
 
 # Datetime when this Beacon was created
 createtime=2018-07-25T00:00:00Z
+
+# GA4GH Discovery type `groupId` and `artifactId`, joined in /service-info with apiVersion
+# See https://github.com/ga4gh-discovery/ga4gh-service-registry for more information and possible values
+service_type=org.ga4gh:beacon
+
+# GA4GH Discovery server environment, possible values: prod, dev, test
+environment=prod
 
 
 [organisation_info]

--- a/deploy/test/auth_test.ini
+++ b/deploy/test/auth_test.ini
@@ -40,6 +40,13 @@ alturl=https://ega-archive.org/
 # Datetime when this Beacon was created
 createtime=2018-07-25T00:00:00Z
 
+# GA4GH Discovery type `groupId` and `artifactId`, joined in /service-info with apiVersion
+# See https://github.com/ga4gh-discovery/ga4gh-service-registry for more information and possible values
+service_type=org.ga4gh:beacon
+
+# GA4GH Discovery server environment, possible values: prod, dev, test
+environment=prod
+
 
 [handover_info]
 # The base url for all handovers

--- a/deploy/test/integ_test.py
+++ b/deploy/test/integ_test.py
@@ -703,6 +703,6 @@ async def test_32():
             data = await resp.json()
             # GA4GH Discovery Service-Info is small and its length should be between 3 and 6, when the Beacon info is very long
             # https://github.com/ga4gh-discovery/service-info/blob/develop/service-info.yaml
-            assert 5 <= len(data) <= 9, 'Service info size error'  # ga4gh service-info has 5 required keys and at most 9 with optionals
-            assert data['type'] == 'urn:ga4gh:beacon', 'Service type error'  # a new key used in beacon network
+            assert len(data) >= 5, 'Service info size error'  # ga4gh service-info has 5 required keys, and option to add custom keys
+            assert data['type'].startswith('org.ga4gh:beacon'), 'Service type error'  # a new key used in beacon network
             assert resp.status == 200, 'HTTP Status code error'

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -115,10 +115,18 @@ Example Response:
   {
     "id": "localhost:5050",
     "name": "GA4GHBeacon at CSC",
+    "type": "org.ga4gh:beacon:1.1.0",
     "description": "Beacon API Web Server based on the GA4GH Beacon API",
-    "documentationUrl": "https://beacon-python.readthedocs.io/en/latest/",
+    "organization": {
+        "name": "CSC - IT Center for Science",
+        "url": "https://www.csc.fi/"
+    },
     "contactUrl": "https://www.csc.fi/contact-info",
-    "version": "1.4.0"
+    "documentationUrl": "https://beacon-network.readthedocs.io/en/latest/",
+    "createdAt": "2019-09-04T12:00:00Z",
+    "updatedAt": "2019-09-05T05:55:18Z",
+    "environment": "prod",
+    "version": "1.4.1"
   }
 
 Query Endpoint

--- a/docs/instructions.rst
+++ b/docs/instructions.rst
@@ -69,7 +69,7 @@ pointing to the location of the file using `CONFIG_FILE` environment variable.
 
 .. literalinclude:: /../beacon_api/conf/config.ini
    :language: python
-   :lines: 1-68
+   :lines: 1-75
 
 .. _oauth2:
 
@@ -81,7 +81,7 @@ The configuration variables reside in the same `CONFIG_FILE` as described above 
 
 .. literalinclude:: /../beacon_api/conf/config.ini
    :language: python
-   :lines: 90-116
+   :lines: 97-123
 
 * ``server`` should point to an API that returns a public key, which can be used to validate the received JWTBearer token.
 * ``issuers`` is a string of comma separated values, e.g. `one,two,three` without spaces. The issuers string should contain

--- a/docs/optionals.rst
+++ b/docs/optionals.rst
@@ -17,7 +17,7 @@ The handover protocol can be configured in ``config.ini`` as follows:
 
 .. literalinclude:: /../beacon_api/conf/config.ini
    :language: python
-   :lines: 71-87
+   :lines: 78-94
 
 .. note:: Handover protocol is disabled by default, as shown by the commented out ``drs`` variable. This variable should point
           to the server, which serves the additional data. To enable the handover protocol, uncomment the ``drs`` variable.

--- a/tests/test.ini
+++ b/tests/test.ini
@@ -40,6 +40,13 @@ alturl=https://ega-archive.org/
 # Datetime when this Beacon was created
 createtime=2018-07-25T00:00:00Z
 
+# GA4GH Discovery type `groupId` and `artifactId`, joined in /service-info with apiVersion
+# See https://github.com/ga4gh-discovery/ga4gh-service-registry for more information and possible values
+service_type=org.ga4gh:beacon
+
+# GA4GH Discovery server environment, possible values: prod, dev, test
+environment=test
+
 
 [handover_info]
 # The base url for all handovers


### PR DESCRIPTION
### Description
The [GA4GH Discovey Service-Info](https://github.com/ga4gh-discovery/ga4gh-service-registry) has been updated, and this PR brings beacon-python up-to-date with that.

### Type of change
- [x] Update

### Changes Made
* Added new key `service_type` to `config.ini` which refers to GA4GH Discovery `groupId` and `artifactId`;
* Added new key `environment` to `config.ini` which states application environment (test, dev, prod);
* Updated `/service-info`;
* Updated tests and documentation;
* Upped version from `1.4.0` to `1.4.1`.

### Testing
- [x] Integration Tests

### Mentions
[GA4GH Discovery](https://github.com/ga4gh-discovery/ga4gh-service-registry/issues/88) is marked to have a `1.0.0` release coming _soon_.