### PR TITLE
Fix integer overflow in beacon_dataset_counts_table

### DIFF
--- a/data/init.sql
+++ b/data/init.sql
@@ -29,7 +29,7 @@ variantcount: SELECT count(*) FROM beacon_data_table;
 CREATE TABLE IF NOT EXISTS beacon_dataset_counts_table (
     datasetId VARCHAR(128),
     callCount INTEGER DEFAULT NULL,
-    variantCount INTEGER DEFAULT NULL
+    variantCount BIGINT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS beacon_data_table (


### PR DESCRIPTION
### Description

Simple fix in init.sql currently seems all that is needed. When updating callcounts and variantcounts variant count is likely to overflow on even medium-sized datasets.

### Related issues
-

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
Changed column type on variantcounts from INTEGER to BIGINT

### Testing
- [x] Tests do not apply
