### PR TITLE
Add CORS headers for max age and allowed methods

### DIFF
--- a/beacon_api/app.py
+++ b/beacon_api/app.py
@@ -94,6 +94,8 @@ def set_cors(server):
             allow_credentials=True,
             expose_headers="*",
             allow_headers="*",
+            allow_methods=["GET", "POST", "OPTIONS"],
+            max_age=86400,
         )
     })
     # Apply CORS to endpoints


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change or any information deemed important. -->
ADD CORS headers for max age and allowed methods.

The `OPTIONS` methods is for preflight requests `aiohttp_cors` should be able to handle preflight see also https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers

### Related issues
<!-- Reference any follow up issues with "Fixes #<issue-num>." -->

### Type of change

<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

<!-- List changes made. -->
1. Added headers as specified by `aiohttp_cors`

### Testing

<!-- Are any tests part of this PR. -->
<!-- Replace [ ] with [x] to select options. -->
<!-- Please delete options that are not relevant. -->


- [x] Tests do not apply
