### PR TITLE
minimum allele count for beacon init

### DIFF
--- a/beacon_api/conf/config.ini
+++ b/beacon_api/conf/config.ini
@@ -7,7 +7,7 @@
 title=GA4GHBeacon at CSC
 
 # Version of the Beacon implementation
-version=1.7.2
+version=1.8.0
 
 # Author of this software
 author=CSC developers

--- a/docs/instructions.rst
+++ b/docs/instructions.rst
@@ -160,10 +160,11 @@ Starting PostgreSQL using Docker:
 .. code-block:: console
 
     cd beacon-python
-    docker run -e POSTGRES_USER=beacon \
+    docker run -d \
+               -e POSTGRES_USER=beacon \
                -e POSTGRES_PASSWORD=beacon \
                -e POSTGRES_DB=beacondb \
-               -v "$PWD/data":/docker-entrypoint-initdb.d
+               -v "$PWD/data":/docker-entrypoint-initdb.d \
                -p 5432:5432 postgres:11.6
 
 .. hint:: If one has their own database the ``beacon_init`` utility can be skipped,
@@ -182,19 +183,25 @@ For loading datasets to database we provide the ``beacon_init`` utility:
 
 .. code-block:: console
 
-    ╰─$ beacon_init --help
-    usage: beacon_init [-h] datafile metadata
+    $ beacon_init --help
+    usage: beacon_init [-h] [--samples SAMPLES]
+                      [--min_allele_count MIN_ALLELE_COUNT]
+                      datafile metadata
 
     Load datafiles with associated metadata into the beacon database. See example
     data and metadata files in the /data directory.
 
     positional arguments:
-      datafile    .vcf file containing variant information
-      metadata    .json file containing metadata associated to datafile
+      datafile              .vcf file containing variant information
+      metadata              .json file containing metadata associated to datafile
 
     optional arguments:
-      --samples   comma separated string of samples to process
-      -h, --help  show this help message and exit
+      -h, --help            show this help message and exit
+      --samples SAMPLES     comma separated string of samples to process.
+                            EXPERIMENTAL
+      --min_allele_count MIN_ALLELE_COUNT
+                            minimum allele count can be raised to ignore rare
+                            variants. Default value is 1
 
 As an example, a dataset metadata could be:
 
@@ -221,11 +228,17 @@ For loading data into the database we can proceed as follows:
 
     $ beacon_init data/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz data/example_metadata.json
 
-For loading data into the database from selected samples only we can proceed as follows:
+(EXPERIMENTAL) For loading data into the database from selected samples only we can proceed as follows:
 
 .. code-block:: console
 
     $ beacon_init data/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz data/example_metadata.json --samples HG0001,HG0002,HG0003
+
+For ignoring rare alleles, set a minimum allele count with ``--min_allele_count``:
+
+.. code-block:: console
+
+    $ beacon_init data/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz data/example_metadata.json --min_allele_count 20
 
 .. note:: One dataset can have multiple files, in order to add more files to one dataset, repeat the command above.
           The parameters ``callCount`` and ``variantCount`` from the metadata file reflect values of the entire dataset.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -59,7 +59,7 @@ class MockBeaconDB:
         """Mimic create_tables."""
         pass
 
-    async def insert_variants(self, dataset_id, variants, len_samples):
+    async def insert_variants(self, dataset_id, variants, min_ac):
         """Mimic insert_variants."""
         pass
 
@@ -67,7 +67,7 @@ class MockBeaconDB:
         """Mimic load_metadata."""
         pass
 
-    async def load_datafile(self, vcf, datafile, datasetId, min_ac=1):
+    async def load_datafile(self, vcf, datafile, datasetId, n=1000, min_ac=1):
         """Mimic load_datafile."""
         return ["datasetId", "variants"]
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -67,7 +67,7 @@ class MockBeaconDB:
         """Mimic load_metadata."""
         pass
 
-    async def load_datafile(self, vcf, datafile, datasetId):
+    async def load_datafile(self, vcf, datafile, datasetId, min_ac=1):
         """Mimic load_datafile."""
         return ["datasetId", "variants"]
 

--- a/tests/test_db_load.py
+++ b/tests/test_db_load.py
@@ -312,7 +312,7 @@ class DatabaseTestCase(asynctest.TestCase):
         db_mock.return_value = Connection()
         await self._db.connection()
         db_mock.assert_called()
-        await self._db.insert_variants('DATASET1', ['C'])
+        await self._db.insert_variants('DATASET1', ['C'], 1)
         # Should assert logs
         mock_log.info.mock_calls = ['Received 1 variants for insertion to DATASET1',
                                     'Insert variants into the database']


### PR DESCRIPTION
### Description
Add option `--min_allele_count` to `beacon_init` tool to be able to ignore rare alleles.

#### Examples
- Default: minimum allele count by default is 1, all variants will be loaded into the database
- `--min_allele_count 20` only variants that have an allele count of at least 20 will be loaded into the database

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Changes Made
- New feature to `db_load.py`
- Updated docs
- Updates unit tests
- Bumped feature number

### Testing
- [x] Unit Tests
- [x] Manual QA

### Mentions
Requested by [THL Biobank](https://thl.fi/en/web/thl-biobank).